### PR TITLE
Fix method ambiguity

### DIFF
--- a/src/common.jl
+++ b/src/common.jl
@@ -115,6 +115,4 @@ end
 ## PDMats ##
 
 PDMats.invquad(Σ::PDiagMat, x::Tracker.TrackedVector) = sum(abs2.(x) ./ Σ.diag)
-getchol(m::PDMats.AbstractPDMat) = m.chol
-getchol(m::PDMats.PDiagMat) = cholesky(Diagonal(m.diag))
-getchol(m::PDMats.ScalMat) = cholesky(Diagonal(fill(m.value, m.dim)))
+PDMats.invquad(Σ::PDMat, x::Tracker.TrackedVector) = sum(abs2, zygote_ldiv(Σ.chol.L, x))


### PR DESCRIPTION
Fixes the method ambiguity errors seen in Turing's CI tests (see, e.g., https://github.com/TuringLang/Turing.jl/pull/1063).

BTW I had some issues reproducing the error locally after skipping some other tests - `import/using`s and definitions/settings of tests that are run prior to the distribution tests affect them. Maybe one could think about using [SafeTestsets](https://github.com/YingboMa/SafeTestsets.jl) to avoid such issues.