### PR TITLE
Run CI tests only once

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,10 @@
 language: julia
 
+# avoids duplicate tests in PRs
+branches:
+  only:
+    - master
+
 os:
   - linux
   - osx
@@ -20,4 +25,6 @@ notifications:
   email: false
 
 after_success:
-  - julia -e 'using Pkg; cd(Pkg.dir("DistributionsAD")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(process_folder())'
+  - if [[ $TRAVIS_JULIA_VERSION = 1.3 ]] && [[ $TRAVIS_OS_NAME = linux ]]; then
+      julia -e 'using Pkg; Pkg.add("Coverage"); using Coverage; Coveralls.submit(process_folder())';
+    fi


### PR DESCRIPTION
Noticed that Travis runs the tests twice for PRs, which should be avoided by this change.