### PR TITLE
Remove definition of eachcol

### DIFF
--- a/src/common.jl
+++ b/src/common.jl
@@ -1,9 +1,5 @@
 ## Generic ##
 
-if VERSION < v"1.1"
-    eachcol(A::AbstractVecOrMat) = (view(A, :, i) for i in axes(A, 2))
-end
-
 function vcatmapreduce(f, args...)
     init = vcat(f(first.(args)...,))
     zipped_args = zip(args...,)


### PR DESCRIPTION
Compat already implements `eachcol` for old Julia versions.