### PR TITLE
Call Zygote.refresh every 10 distributions in tests

### DIFF
--- a/.github/workflows/ForwardDiff_Tracker.yml
+++ b/.github/workflows/ForwardDiff_Tracker.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        julia-version: [1.0.5, 1.2.0, 1.3]
+        julia-version: [1.0, 1.3]
         julia-arch: [x64, x86]
         os: [ubuntu-latest, macOS-latest]
         exclude:

--- a/.github/workflows/Others.yml
+++ b/.github/workflows/Others.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        julia-version: [1.0.5, 1.2.0, 1.3]
+        julia-version: [1.0, 1.3]
         julia-arch: [x64, x86]
         os: [ubuntu-latest, macOS-latest]
         exclude:

--- a/.github/workflows/Zygote.yml
+++ b/.github/workflows/Zygote.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        julia-version: [1.0.5, 1.2.0, 1.3]
+        julia-version: [1.0, 1.3]
         julia-arch: [x64, x86]
         os: [ubuntu-latest, macOS-latest]
         exclude:

--- a/test/others.jl
+++ b/test/others.jl
@@ -132,7 +132,7 @@ if get_stage() in ("Others", "all")
         d1 = TuringDiagMvNormal(zeros(10), sigmas)
         d2 = MvNormal(zeros(10), sigmas)
 
-        @test entropy(d1) == entropy(d2)
+        @test isapprox(entropy(d1), entropy(d2), rtol = 1e-6)
     end
 
     @testset "Params" begin

--- a/test/test_utils.jl
+++ b/test/test_utils.jl
@@ -181,7 +181,7 @@ function test_ad(f, at = 0.5; rtol = 1e-8, atol = 1e-8)
     elseif stg == "Zygote"
         zygote_counter[] += 1
         isarr = isa(at, AbstractArray)
-        if mod(zygote_counter[], 10) == 0
+        if mod(zygote_counter[], 50) == 0
             Zygote.refresh()
         end
         reverse_zygote = Zygote.gradient(f, at)[1]

--- a/test/test_utils.jl
+++ b/test/test_utils.jl
@@ -147,6 +147,8 @@ function get_stage()
     return "all"
 end
 
+const zygote_counter = Ref(0)
+
 function test_ad(f, at = 0.5; rtol = 1e-8, atol = 1e-8)
     stg = get_stage()
     if stg == "all"
@@ -177,7 +179,11 @@ function test_ad(f, at = 0.5; rtol = 1e-8, atol = 1e-8)
             @test isapprox(reverse_tracker, finite_diff, rtol=rtol, atol=atol)
         end
     elseif stg == "Zygote"
+        zygote_counter[] += 1
         isarr = isa(at, AbstractArray)
+        if mod(zygote_counter[], 10) == 0
+            Zygote.refresh()
+        end
         reverse_zygote = Zygote.gradient(f, at)[1]
         if isarr
             forward = ForwardDiff.gradient(f, at)


### PR DESCRIPTION
This PR fixes the spontaneous segfaulting that happens in Zygote tests. It worked locally when I called refresh after every distribution but it took a long time. Let's see if this passes tests.