### PR TITLE
Update and fix CI tests

### DIFF
--- a/.github/workflows/CompatHelper.yml
+++ b/.github/workflows/CompatHelper.yml
@@ -1,26 +1,19 @@
 name: CompatHelper
 
 on:
-  # push:
   schedule:
-    - cron: '00 * * * *'
+    - cron: '00 00 * * *'
 
 jobs:
-  build:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        julia-version: [1.3]
-        julia-arch: [x86]
-        os: [ubuntu-latest]
+  CompatHelper:
+    runs-on: ubuntu-latest
     steps:
       - uses: julia-actions/setup-julia@latest
         with:
-          version: ${{ matrix.julia-version }}
-      - name: Install dependencies
+          version: 1.4
+      - name: Pkg.add("CompatHelper")
         run: julia -e 'using Pkg; Pkg.add("CompatHelper")'
-      - name: CompatHelper.main
+      - name: CompatHelper.main()
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          JULIA_DEBUG: CompatHelper
         run: julia -e 'using CompatHelper; CompatHelper.main()'

--- a/.github/workflows/ForwardDiff_Tracker.yml
+++ b/.github/workflows/ForwardDiff_Tracker.yml
@@ -5,25 +5,31 @@ on:
     branches:
       - master
   pull_request:
-    types: [opened, synchronize, reopened]
 
 jobs:
   test:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        julia-version: [1.0, 1.3]
-        julia-arch: [x64, x86]
-        os: [ubuntu-latest, macOS-latest]
+        version:
+          - '1.0'
+          - '1.4'
+        os:
+          - ubuntu-latest
+          - macOS-latest 
+        arch:
+          - x86
+          - x64
         exclude:
           - os: macOS-latest
-            julia-arch: x86
-
+            arch: x86
     steps:
-      - uses: actions/checkout@v1.0.0
-      - uses: julia-actions/setup-julia@latest
+      - uses: actions/checkout@v2
+      - uses: julia-actions/setup-julia@v1
         with:
-          version: ${{ matrix.julia-version }}
-      - uses: julia-actions/julia-runtest@master
+          version: ${{ matrix.version }}
+          arch: ${{ matrix.arch }}
+      - uses: julia-actions/julia-buildpkg@latest
+      - uses: julia-actions/julia-runtest@latest
         env:
           STAGE: ForwardDiff_Tracker

--- a/.github/workflows/ForwardDiff_Tracker.yml
+++ b/.github/workflows/ForwardDiff_Tracker.yml
@@ -18,11 +18,7 @@ jobs:
           - ubuntu-latest
           - macOS-latest 
         arch:
-          - x86
           - x64
-        exclude:
-          - os: macOS-latest
-            arch: x86
     steps:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@v1

--- a/.github/workflows/Others.yml
+++ b/.github/workflows/Others.yml
@@ -5,25 +5,31 @@ on:
     branches:
       - master
   pull_request:
-    types: [opened, synchronize, reopened]
 
 jobs:
   test:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        julia-version: [1.0, 1.3]
-        julia-arch: [x64, x86]
-        os: [ubuntu-latest, macOS-latest]
+        version:
+          - '1.0'
+          - '1.4'
+        os:
+          - ubuntu-latest
+          - macOS-latest 
+        arch:
+          - x86
+          - x64
         exclude:
           - os: macOS-latest
-            julia-arch: x86
-
+            arch: x86
     steps:
-      - uses: actions/checkout@v1.0.0
-      - uses: julia-actions/setup-julia@latest
+      - uses: actions/checkout@v2
+      - uses: julia-actions/setup-julia@v1
         with:
-          version: ${{ matrix.julia-version }}
-      - uses: julia-actions/julia-runtest@master
+          version: ${{ matrix.version }}
+          arch: ${{ matrix.arch }}
+      - uses: julia-actions/julia-buildpkg@latest
+      - uses: julia-actions/julia-runtest@latest
         env:
           STAGE: Others

--- a/.github/workflows/Others.yml
+++ b/.github/workflows/Others.yml
@@ -18,11 +18,7 @@ jobs:
           - ubuntu-latest
           - macOS-latest
         arch:
-          - x86
           - x64
-        exclude:
-          - os: macOS-latest
-            arch: x86
     steps:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@v1

--- a/.github/workflows/ReverseDiff.yml
+++ b/.github/workflows/ReverseDiff.yml
@@ -5,25 +5,31 @@ on:
     branches:
       - master
   pull_request:
-    types: [opened, synchronize, reopened]
 
 jobs:
   test:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        julia-version: [1.0, 1.3]
-        julia-arch: [x64, x86]
-        os: [ubuntu-latest, macOS-latest]
+        version:
+          - '1.0'
+          - '1.4'
+        os:
+          - ubuntu-latest
+          - macOS-latest 
+        arch:
+          - x86
+          - x64
         exclude:
           - os: macOS-latest
-            julia-arch: x86
-
+            arch: x86
     steps:
-      - uses: actions/checkout@v1.0.0
-      - uses: julia-actions/setup-julia@latest
+      - uses: actions/checkout@v2
+      - uses: julia-actions/setup-julia@v1
         with:
-          version: ${{ matrix.julia-version }}
-      - uses: julia-actions/julia-runtest@master
+          version: ${{ matrix.version }}
+          arch: ${{ matrix.arch }}
+      - uses: julia-actions/julia-buildpkg@latest
+      - uses: julia-actions/julia-runtest@latest
         env:
           STAGE: ReverseDiff

--- a/.github/workflows/ReverseDiff.yml
+++ b/.github/workflows/ReverseDiff.yml
@@ -18,11 +18,7 @@ jobs:
           - ubuntu-latest
           - macOS-latest 
         arch:
-          - x86
           - x64
-        exclude:
-          - os: macOS-latest
-            arch: x86
     steps:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@v1

--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -1,7 +1,7 @@
 name: TagBot
 on:
   schedule:
-    - cron: 0 * * * *
+    - cron: 0 0 * * *
 jobs:
   TagBot:
     runs-on: ubuntu-latest

--- a/.github/workflows/Zygote.yml
+++ b/.github/workflows/Zygote.yml
@@ -5,25 +5,31 @@ on:
     branches:
       - master
   pull_request:
-    types: [opened, synchronize, reopened]
 
 jobs:
   test:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        julia-version: [1.0, 1.3]
-        julia-arch: [x64, x86]
-        os: [ubuntu-latest, macOS-latest]
+        version:
+          - '1.0'
+          - '1.4'
+        os:
+          - ubuntu-latest
+          - macOS-latest 
+        arch:
+          - x86
+          - x64
         exclude:
           - os: macOS-latest
-            julia-arch: x86
-
+            arch: x86
     steps:
-      - uses: actions/checkout@v1.0.0
-      - uses: julia-actions/setup-julia@latest
+      - uses: actions/checkout@v2
+      - uses: julia-actions/setup-julia@v1
         with:
-          version: ${{ matrix.julia-version }}
-      - uses: julia-actions/julia-runtest@master
+          version: ${{ matrix.version }}
+          arch: ${{ matrix.arch }}
+      - uses: julia-actions/julia-buildpkg@latest
+      - uses: julia-actions/julia-runtest@latest
         env:
           STAGE: Zygote

--- a/.github/workflows/Zygote.yml
+++ b/.github/workflows/Zygote.yml
@@ -18,11 +18,7 @@ jobs:
           - ubuntu-latest
           - macOS-latest 
         arch:
-          - x86
           - x64
-        exclude:
-          - os: macOS-latest
-            arch: x86
     steps:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@v1

--- a/src/reversediff.jl
+++ b/src/reversediff.jl
@@ -2,7 +2,9 @@ include("reversediffx.jl")
 
 import Distributions: Gamma
 using .ReverseDiffX
-using .ReverseDiffX: RTR, RTV, RTM
+using .ReverseDiffX: RTR, RTV, RTM, RTA
+
+PoissonBinomial(p::RTA{<:Real}; check_args=true) = TuringPoissonBinomial(p; check_args = check_args)
 
 Gamma(α::RTR, θ::Real; check_args=true) = pgamma(α, θ, check_args = check_args)
 Gamma(α::Real, θ::RTR; check_args=true) = pgamma(α, θ, check_args = check_args)

--- a/src/univariate.jl
+++ b/src/univariate.jl
@@ -261,16 +261,17 @@ struct TuringPoissonBinomial{T<:Real, TV1<:AbstractVector{T}, TV2<:AbstractVecto
     p::TV1
     pmf::TV2
 end
-function TuringPoissonBinomial(p::AbstractArray{<:Real})
+function TuringPoissonBinomial(p::AbstractArray{<:Real}; check_args = true)
     pb = Distributions.poissonbinomial_pdf_fft(p)
-    @assert Distributions.isprobvec(pb)
-    TuringPoissonBinomial(p, pb)
+    ϵ = eps(eltype(pb))
+    check_args && @assert all(x -> x >= -ϵ, pb) && isapprox(sum(pb), 1, atol = ϵ)
+    return TuringPoissonBinomial(p, pb)
 end
 function logpdf(d::TuringPoissonBinomial{T}, k::Int) where T<:Real
     insupport(d, k) ? log(d.pmf[k + 1]) : -T(Inf)
 end
 quantile(d::TuringPoissonBinomial, x::Float64) = quantile(Categorical(d.pmf), x) - 1
-PoissonBinomial(p::TrackedArray) = TuringPoissonBinomial(p)
+PoissonBinomial(p::TrackedArray{<:Real}; check_args=true) = TuringPoissonBinomial(p; check_args = check_args)
 Base.minimum(d::TuringPoissonBinomial) = 0
 Base.maximum(d::TuringPoissonBinomial) = length(d.p)
 


### PR DESCRIPTION
This PR updates all CI tests to run on Julia 1.4 and 1.0 and reduces the frequency of TagBot and CompatHelper to once per day. Although intended otherwise, CI tests were not run on Julia 1.0 before (`[1.0, 1.3]` is interpreted as `[1, 1.3]`).