### PR TITLE
Drop Zygote dependency and reformat code

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -20,7 +20,6 @@ StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 StatsFuns = "4c63d2b9-4356-54db-8cca-17b64c39e42c"
 Tracker = "9f7883ad-71c0-57eb-9f7f-b5c9e6d3789c"
-Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 ZygoteRules = "700de1a5-db45-46bc-99cf-38207098b444"
 
 [compat]
@@ -36,8 +35,8 @@ NaNMath = "0.3"
 PDMats = "0.9"
 Requires = "1"
 SpecialFunctions = "0.8, 0.9, 0.10"
-StatsBase = "0.32, 0.33"
 StaticArrays = "0.12"
+StatsBase = "0.32, 0.33"
 StatsFuns = "0.8, 0.9"
 Tracker = "0.2.5"
 Zygote = "0.4.10"
@@ -48,6 +47,7 @@ julia = "1"
 FiniteDifferences = "26cc04aa-876d-5657-8c51-4c34ba976000"
 ReverseDiff = "37e2e3b7-166d-5795-8a7a-e32c996b4267"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 
 [targets]
-test = ["FiniteDifferences", "Test", "ReverseDiff"]
+test = ["FiniteDifferences", "Test", "ReverseDiff", "Zygote"]

--- a/src/DistributionsAD.jl
+++ b/src/DistributionsAD.jl
@@ -2,7 +2,6 @@ module DistributionsAD
 
 using PDMats, 
       ForwardDiff, 
-      Zygote, 
       LinearAlgebra, 
       Distributions, 
       Random, 
@@ -15,7 +14,6 @@ using PDMats,
 using Tracker: Tracker, TrackedReal, TrackedVector, TrackedMatrix, TrackedArray,
                 TrackedVecOrMat, track, @grad, data
 using SpecialFunctions: logabsgamma, digamma
-using ZygoteRules: ZygoteRules, @adjoint, pullback
 using LinearAlgebra: copytri!, AbstractTriangular
 using Distributions: AbstractMvLogNormal, 
                      ContinuousMultivariateDistribution
@@ -37,6 +35,7 @@ import Distributions: MvNormal,
                       Binomial,
                       BetaBinomial,
                       Erlang
+import ZygoteRules
 
 export TuringScalMvNormal,
        TuringDiagMvNormal,

--- a/src/filldist.jl
+++ b/src/filldist.jl
@@ -25,11 +25,11 @@ function Distributions.logpdf(
 )
     return _logpdf(dist, x)
 end
-@adjoint function Distributions.logpdf(
+ZygoteRules.@adjoint function Distributions.logpdf(
     dist::FillVectorOfUnivariate,
     x::AbstractMatrix{<:Real},
 )
-    return pullback(_logpdf, dist, x)
+    return ZygoteRules.pullback(_logpdf, dist, x)
 end
 
 function _logpdf(
@@ -104,11 +104,11 @@ function _logpdf(
 )
     return sum(logpdf(dist.dists.value, x))
 end
-@adjoint function Distributions.logpdf(
+ZygoteRules.@adjoint function Distributions.logpdf(
     dist::FillVectorOfMultivariate,
     x::AbstractMatrix{<:Real},
 )
-    return pullback(_logpdf, dist, x)
+    return ZygoteRules.pullback(_logpdf, dist, x)
 end
 function Distributions.rand(rng::Random.AbstractRNG, dist::FillVectorOfMultivariate)
     return rand(rng, dist.dists.value, length.(dist.dists.axes)...,)

--- a/src/matrixvariate.jl
+++ b/src/matrixvariate.jl
@@ -3,9 +3,13 @@
 function Distributions.logpdf(d::MatrixBeta, X::AbstractArray{<:TrackedMatrix{<:Real}})
     return map(x -> logpdf(d, x), X)
 end
-@adjoint function Distributions.logpdf(d::MatrixBeta, X::AbstractArray{<:Matrix{<:Real}})
-    f(d, X) = map(x -> logpdf(d, x), X)
-    return pullback(f, d, X)
+ZygoteRules.@adjoint function Distributions.logpdf(
+    d::MatrixBeta,
+    X::AbstractArray{<:Matrix{<:Real}}
+)
+    return ZygoteRules.pullback(d, X) do d, X
+        map(x -> logpdf(d, x), X)
+    end
 end
 
 # Adapted from Distributions.jl
@@ -248,11 +252,14 @@ end
 
 ## Adjoints
 
-@adjoint function Distributions.Wishart(df::Real, S::AbstractMatrix{<:Real})
-    return pullback(TuringWishart, df, S)
+ZygoteRules.@adjoint function Distributions.Wishart(df::Real, S::AbstractMatrix{<:Real})
+    return ZygoteRules.pullback(TuringWishart, df, S)
 end
-@adjoint function Distributions.InverseWishart(df::Real, S::AbstractMatrix{<:Real})
-    return pullback(TuringInverseWishart, df, S)
+ZygoteRules.@adjoint function Distributions.InverseWishart(
+    df::Real,
+    S::AbstractMatrix{<:Real}
+)
+    return ZygoteRules.pullback(TuringInverseWishart, df, S)
 end
 
 Distributions.Wishart(df::TrackedReal, S::Matrix{<:Real}) = TuringWishart(df, S)

--- a/src/reversediff.jl
+++ b/src/reversediff.jl
@@ -10,10 +10,11 @@ using ..DistributionsAD: DistributionsAD, _turing_chol
 
 const TrackedVecOrMat{V,D} = Union{TrackedVector{V,D},TrackedMatrix{V,D}}
 
-import SpecialFunctions, NaNMath, Zygote
+import SpecialFunctions, NaNMath
 import ..DistributionsAD: turing_chol
 import Base.Broadcast: materialize
 import StatsFuns: logsumexp
+import ZygoteRules
 
 const RDBroadcasted{F, T} = Broadcasted{<:Any, <:Any, F, T}
 

--- a/src/reversediffx.jl
+++ b/src/reversediffx.jl
@@ -141,7 +141,7 @@ function turing_chol(x::TrackedArray{V,D}, check) where {V,D}
     tp = tape(x)
     x_value = value(x)
     check_value = value(check)
-    C, back = Zygote.pullback(_turing_chol, x_value, check_value)
+    C, back = ZygoteRules.pullback(_turing_chol, x_value, check_value)
     out = track(C.factors, D, tp)
     record!(tp, SpecialInstruction, turing_chol, (x, check), out, (back, issuccess(C)))
     return out, C.info

--- a/src/univariate.jl
+++ b/src/univariate.jl
@@ -45,7 +45,7 @@ uniformlogpdf(a::TrackedReal, b::TrackedReal, x::TrackedReal) = track(uniformlog
         return n, Δ -> (n, n, n)
     end
 end
-@adjoint function uniformlogpdf(a, b, x)
+ZygoteRules.@adjoint function uniformlogpdf(a, b, x)
     diff = b - a
     T = typeof(diff)
     if a <= x <= b && a < b
@@ -57,8 +57,8 @@ end
         return n, Δ -> (n, n, n)
     end
 end
-@adjoint function Distributions.Uniform(args...)
-    return pullback(TuringUniform, args...)
+ZygoteRules.@adjoint function Distributions.Uniform(args...)
+    return ZygoteRules.pullback(TuringUniform, args...)
 end
 
 ## Beta ##
@@ -70,7 +70,7 @@ function _betalogpdfgrad(α, β, x)
     dx = (α - 1)/x + (1 - β)/(1 - x)
     return (dα, dβ, dx)
 end
-@adjoint function betalogpdf(α::Real, β::Real, x::Number)
+ZygoteRules.@adjoint function betalogpdf(α::Real, β::Real, x::Number)
     return betalogpdf(α, β, x), Δ -> (Δ .* _betalogpdfgrad(α, β, x))
 end    
 
@@ -82,7 +82,7 @@ function _gammalogpdfgrad(k, θ, x)
     dx = (k - 1)/x - 1/θ
     return (dk, dθ, dx)
 end
-@adjoint function gammalogpdf(k::Real, θ::Real, x::Number)
+ZygoteRules.@adjoint function gammalogpdf(k::Real, θ::Real, x::Number)
     return gammalogpdf(k, θ, x), Δ -> (Δ .* _gammalogpdfgrad(k, θ, x))
 end    
 
@@ -95,7 +95,7 @@ function _chisqlogpdfgrad(k, x)
     dx = (hk - 1)/x - one(hk)/2
     return (dk, dx)
 end
-@adjoint function chisqlogpdf(k::Real, x::Number)
+ZygoteRules.@adjoint function chisqlogpdf(k::Real, x::Number)
     return chisqlogpdf(k, x), Δ -> (Δ .* _chisqlogpdfgrad(k, x))
 end    
 
@@ -112,7 +112,7 @@ function _fdistlogpdfgrad(v1, v2, x)
     dx = v1 / 2 * (1 / x - temp3) - 1 / x
     return (dv1, dv2, dx)
 end
-@adjoint function fdistlogpdf(v1::Real, v2::Real, x::Number)
+ZygoteRules.@adjoint function fdistlogpdf(v1::Real, v2::Real, x::Number)
     return fdistlogpdf(v1, v2, x), Δ -> (Δ .* _fdistlogpdfgrad(v1, v2, x))
 end
 
@@ -123,7 +123,7 @@ function _tdistlogpdfgrad(v, x)
     dx = -x * (v + 1) / (v + x^2)
     return (dv, dx)
 end
-@adjoint function tdistlogpdf(v::Real, x::Number)
+ZygoteRules.@adjoint function tdistlogpdf(v::Real, x::Number)
     return tdistlogpdf(v, x), Δ -> (Δ .* _tdistlogpdfgrad(v, x))
 end
 
@@ -166,7 +166,7 @@ binomlogpdf(n::Int, p::TrackedReal, x::Int) = track(binomlogpdf, n, p, x)
     return binomlogpdf(n, data(p), x),
         Δ->(nothing, Δ * (x / p - (n - x) / (1 - p)), nothing)
 end
-@adjoint function binomlogpdf(n::Int, p::Real, x::Int)
+ZygoteRules.@adjoint function binomlogpdf(n::Int, p::Real, x::Int)
     return binomlogpdf(n, p, x),
         Δ->(nothing, Δ * (x / p - (n - x) / (1 - p)), nothing)
 end
@@ -243,7 +243,7 @@ poislogpdf(v::TrackedReal, x::Int) = track(poislogpdf, v, x)
       return poislogpdf(data(v), x),
           Δ->(Δ * (x/v - 1), nothing)
 end
-@adjoint function poislogpdf(v::Real, x::Int)
+ZygoteRules.@adjoint function poislogpdf(v::Real, x::Int)
     return poislogpdf(v, x),
         Δ->(Δ * (x/v - 1), nothing)
 end
@@ -285,7 +285,7 @@ poissonbinomial_pdf_fft(x::TrackedArray) = track(poissonbinomial_pdf_fft, x)
     end
 end
 # FIXME: This is inefficient, replace with the commented code below once Zygote supports it.
-@adjoint function poissonbinomial_pdf_fft(x::AbstractArray)
+ZygoteRules.@adjoint function poissonbinomial_pdf_fft(x::AbstractArray)
     T = eltype(x)
     fft = poissonbinomial_pdf_fft(x)
     return  fft, Δ -> begin
@@ -295,8 +295,8 @@ end
 
 # The code below doesn't work because of bugs in Zygote. The above is inefficient.
 #=
-@adjoint function poissonbinomial_pdf_fft(x::AbstractArray{<:Real})
-    return pullback(poissonbinomial_pdf_fft_zygote, x)
+ZygoteRules.@adjoint function poissonbinomial_pdf_fft(x::AbstractArray{<:Real})
+    return ZygoteRules.pullback(poissonbinomial_pdf_fft_zygote, x)
 end
 function poissonbinomial_pdf_fft_zygote(p::AbstractArray{T}) where {T <: Real}
     n = length(p)


### PR DESCRIPTION
This PR removes the Zygote dependency, as discussed in https://github.com/TuringLang/DistributionsAD.jl/issues/65#issuecomment-619516746. Moreover, currently sometimes the explicit `ZygoteRules.@adjoint` and `ZygoteRules.pullback` was used and sometimes only `@adjoint` and `pullback`. I reformatted the code (adhering to the 92 characters limit) so that now consistently the more explict `ZygoteRules.@adjoint` and `ZygoteRules.pullback` are used to show clearly that these implementations use Zygote.