### PR TITLE
[WIP] Add eps to probs in discrete distributions

### DIFF
--- a/src/reversediff.jl
+++ b/src/reversediff.jl
@@ -258,11 +258,12 @@ end
 _mv_categorical_logpdf(ps::TrackedMatrix, x) = track(_mv_categorical_logpdf, ps, x)
 @grad function _mv_categorical_logpdf(ps, x)
     ps_data = value(ps)
+    T = eltype(ps_data)
     probs = view(ps_data, x, :)
     ps_grad = zero(ps_data)
     sum(log, probs), Δ -> begin
         ps_grad .= 0
-        ps_grad[x,:] .= Δ ./ probs
+        ps_grad[x,:] .= Δ ./ (probs .+ eps(T))
         return (ps_grad, nothing)
     end
 end


### PR DESCRIPTION
This PR adds eps to the probabilities in MvCategorical to avoid `-Inf` from showing when starting from a bad initial value in Turing. The same needs to be done or all the other discrete distributions.