### PR TITLE
Support cholesky of Symmetric and refactor some tests

### DIFF
--- a/src/reversediff.jl
+++ b/src/reversediff.jl
@@ -6,12 +6,12 @@ using MacroTools, LinearAlgebra, ..ReverseDiff, StaticArrays
 using Base.Broadcast: BroadcastStyle, ArrayStyle, Broadcasted, broadcasted
 using ForwardDiff: ForwardDiff, Dual
 using ..ReverseDiff: SpecialInstruction, value, value!, deriv, track, record!, tape, unseed!, @grad, TrackedReal, TrackedVector, TrackedMatrix, TrackedArray
-using ..DistributionsAD: DistributionsAD, _turing_chol
+using ..DistributionsAD: DistributionsAD
 
 const TrackedVecOrMat{V,D} = Union{TrackedVector{V,D},TrackedMatrix{V,D}}
 
 import SpecialFunctions, NaNMath
-import ..DistributionsAD: turing_chol, _mv_categorical_logpdf
+import ..DistributionsAD: turing_chol, symm_turing_chol, _mv_categorical_logpdf
 import Base.Broadcast: materialize
 import StatsFuns: logsumexp
 import ZygoteRules

--- a/src/reversediffx.jl
+++ b/src/reversediffx.jl
@@ -154,36 +154,69 @@ Base.:*(A::Adjoint{<:Real, <:TrackedVector{<:Real}}, B::TrackedVector{<:Real}) =
 Base.:*(A::AbstractVector{<:Real}, B::Adjoint{<:Real, <:TrackedVector{<:Real}}) = dot(A, B)
 Base.:*(A::TrackedVector{<:Real}, B::Adjoint{<:Real, <:TrackedVector{<:Real}}) = dot(A, B)
 
+function LinearAlgebra.cholesky(A::Symmetric{<:Any, <:TrackedMatrix}; check=true)
+    uplo = A.uplo == 'U' ? (:U) : (:L)
+    factors, info = symm_turing_chol(parent(A), check, uplo)
+    return Cholesky{eltype(factors), typeof(factors)}(factors, 'U', info)
+end
 function LinearAlgebra.cholesky(A::TrackedMatrix; check=true)
     factors, info = turing_chol(A, check)
     return Cholesky{eltype(factors), typeof(factors)}(factors, 'U', info)
 end
 
+function symm_turing_chol(x::TrackedArray{V,D}, check, uplo) where {V,D}
+    tp = tape(x)
+    x_value = value(x)
+    C, back = ZygoteRules.pullback(x_value, check, uplo) do A, check, uplo
+        cholesky(Symmetric(A, uplo), check=check)
+    end
+    out = track(C.factors, D, tp)
+    record!(tp, SpecialInstruction, symm_turing_chol, (x, check, uplo), out, (back, issuccess(C)))
+    return out, C.info
+end
 function turing_chol(x::TrackedArray{V,D}, check) where {V,D}
     tp = tape(x)
     x_value = value(x)
-    check_value = value(check)
-    C, back = ZygoteRules.pullback(_turing_chol, x_value, check_value)
+    C, back = ZygoteRules.pullback(x_value, check) do A, check
+        cholesky(A, check=check)
+    end
     out = track(C.factors, D, tp)
     record!(tp, SpecialInstruction, turing_chol, (x, check), out, (back, issuccess(C)))
     return out, C.info
 end
 
-@noinline function ReverseDiff.special_reverse_exec!(instruction::SpecialInstruction{typeof(turing_chol)})
-    output = instruction.output
-    instruction.cache[2] || throw(PosDefException(C.info))
-    input = instruction.input
-    input_deriv = deriv(input[1])
-    P = instruction.cache[1]
-    input_deriv .+= P((factors = deriv(output),))[1]
-    unseed!(output)
+for f in (:turing_chol, :symm_turing_chol)
+    @eval begin
+        @noinline function ReverseDiff.special_reverse_exec!(
+            instruction::SpecialInstruction{typeof($f)},
+        )
+            output = instruction.output
+            instruction.cache[2] || throw(PosDefException(C.info))
+            input = instruction.input
+            input_deriv = deriv(input[1])
+            P = instruction.cache[1]
+            input_deriv .+= P((factors = deriv(output),))[1]
+            unseed!(output)
+            return nothing
+        end
+    end
+end
+
+@noinline function ReverseDiff.special_forward_exec!(
+    instruction::SpecialInstruction{typeof(turing_chol)},
+)
+    output, input = instruction.output, instruction.input
+    factors = turing_chol(value.(input)...)[1]
+    value!(output, factors)
     return nothing
 end
 
-@noinline function ReverseDiff.special_forward_exec!(instruction::SpecialInstruction{typeof(turing_chol)})
+@noinline function ReverseDiff.special_forward_exec!(
+    instruction::SpecialInstruction{typeof(symm_turing_chol)},
+)
     output, input = instruction.output, instruction.input
-    C = cholesky(value(input[1]), check = value(input[2]))
-    value!(output, C.factors)
+    factors = symm_turing_chol(value.(input)...)[1]
+    value!(output, factors)
     return nothing
 end
 


### PR DESCRIPTION
This PR refactors the cholesky adjoints and extends them to handle the cholesky of matrices wrapped by `Symmetric`. Some tests were moved from Turing to this repo. Also the `ReverseDiff.@grad` tests were removed from this repo because they exist in `ReverseDiff` now.