### PR TITLE
Define custom adjoint for simplex_logpdf

### DIFF
--- a/src/multivariate.jl
+++ b/src/multivariate.jl
@@ -79,6 +79,25 @@ function simplex_logpdf(alpha, lmnB, x::AbstractMatrix)
     end
 end
 
+for func_header in [
+    :(simplex_logpdf(alpha::TrackedVector, lmnB::Real, x::AbstractVector)),
+    :(simplex_logpdf(alpha::AbstractVector, lmnB::TrackedReal, x::AbstractVector)),
+    :(simplex_logpdf(alpha::AbstractVector, lmnB::Real, x::TrackedVector)),
+    :(simplex_logpdf(alpha::TrackedVector, lmnB::TrackedReal, x::AbstractVector)),
+    :(simplex_logpdf(alpha::AbstractVector, lmnB::TrackedReal, x::TrackedVector)),
+    :(simplex_logpdf(alpha::TrackedVector, lmnB::Real, x::TrackedVector)),
+    :(simplex_logpdf(alpha::TrackedVector, lmnB::TrackedReal, x::TrackedVector)),
+
+    :(simplex_logpdf(alpha::TrackedVector, lmnB::Real, x::AbstractMatrix)),
+    :(simplex_logpdf(alpha::AbstractVector, lmnB::TrackedReal, x::AbstractMatrix)),
+    :(simplex_logpdf(alpha::AbstractVector, lmnB::Real, x::TrackedMatrix)),
+    :(simplex_logpdf(alpha::TrackedVector, lmnB::TrackedReal, x::AbstractMatrix)),
+    :(simplex_logpdf(alpha::AbstractVector, lmnB::TrackedReal, x::TrackedMatrix)),
+    :(simplex_logpdf(alpha::TrackedVector, lmnB::Real, x::TrackedMatrix)),
+    :(simplex_logpdf(alpha::TrackedVector, lmnB::TrackedReal, x::TrackedMatrix)),
+]
+    @eval $func_header = Tracker.track(simplex_logpdf, alpha, lmnB, x)
+end
 Tracker.@grad function simplex_logpdf(alpha, lmnB, x::AbstractVector)
     simplex_logpdf(data(alpha), data(lmnB), data(x)), Δ -> begin
         (Δ .* log.(data(x)), -Δ, Δ .* (data(alpha) .- 1))


### PR DESCRIPTION
This PR fixes a performance regression in the LDA and hmm_semisup benchmarks in TuringExamples when using the latest release of DistributionsAD compared to the branch used in TuringExamples#master.