### PR TITLE
Fix CompatHelper

### DIFF
--- a/.github/workflows/CompatHelper.yml
+++ b/.github/workflows/CompatHelper.yml
@@ -8,12 +8,10 @@ jobs:
   CompatHelper:
     runs-on: ubuntu-latest
     steps:
-      - uses: julia-actions/setup-julia@latest
-        with:
-          version: 1
       - name: Pkg.add("CompatHelper")
         run: julia -e 'using Pkg; Pkg.add("CompatHelper")'
       - name: CompatHelper.main()
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          COMPATHELPER_PRIV: ${{ secrets.COMPATHELPER_PRIV }}
         run: julia -e 'using CompatHelper; CompatHelper.main()'


### PR DESCRIPTION
This PR fixes CompatHelper (there's no need to install Julia, CompatHelper takes care of that) and sets it up for running the CI tests on Github (currently CompatHelper does not run any tests).

~~Someone with sufficient permissions has to follow the steps in https://github.com/bcbi/CompatHelper.jl#122-instructions-for-setting-up-the-ssh-deploy-key and add a private key and a deploy key to make it actually work.~~
Edit: Seems I could fix it.