### PR TITLE
Test AD wrt `x` and fixed `theta` if possible

### DIFF
--- a/src/multivariate.jl
+++ b/src/multivariate.jl
@@ -170,20 +170,20 @@ end
 for T in (:TrackedVector, :TrackedMatrix)
     @eval begin
         function Distributions.logpdf(d::MvNormal{<:Any, <:PDMats.ScalMat}, x::$T)
-            logpdf(TuringScalMvNormal(d.μ, d.Σ.value), x)
+            logpdf(TuringScalMvNormal(d.μ, sqrt(d.Σ.value)), x)
         end
         function Distributions.logpdf(d::MvNormal{<:Any, <:PDMats.PDiagMat}, x::$T)
-            logpdf(TuringDiagMvNormal(d.μ, d.Σ.diag), x)
+            logpdf(TuringDiagMvNormal(d.μ, sqrt.(d.Σ.diag)), x)
         end
         function Distributions.logpdf(d::MvNormal{<:Any, <:PDMats.PDMat}, x::$T)
             logpdf(TuringDenseMvNormal(d.μ, d.Σ.chol), x)
         end
         
         function Distributions.logpdf(d::MvLogNormal{<:Any, <:PDMats.ScalMat}, x::$T)
-            logpdf(TuringMvLogNormal(TuringScalMvNormal(d.normal.μ, d.normal.Σ.value)), x)
+            logpdf(TuringMvLogNormal(TuringScalMvNormal(d.normal.μ, sqrt(d.normal.Σ.value))), x)
         end
         function Distributions.logpdf(d::MvLogNormal{<:Any, <:PDMats.PDiagMat}, x::$T)
-            logpdf(TuringMvLogNormal(TuringDiagMvNormal(d.normal.μ, d.normal.Σ.diag)), x)
+            logpdf(TuringMvLogNormal(TuringDiagMvNormal(d.normal.μ, sqrt.(d.normal.Σ.diag))), x)
         end
         function Distributions.logpdf(d::MvLogNormal{<:Any, <:PDMats.PDMat}, x::$T)
             logpdf(TuringMvLogNormal(TuringDenseMvNormal(d.normal.μ, d.normal.Σ.chol)), x)

--- a/src/multivariate.jl
+++ b/src/multivariate.jl
@@ -406,7 +406,7 @@ for T in (:AbstractVector, :AbstractMatrix)
             x::$T
         )
             return ZygoteRules.pullback(d, x) do d, x
-                logpdf(TuringScalMvNormal(d.μ, d.Σ.value), x)
+                logpdf(TuringScalMvNormal(d.μ, sqrt(d.Σ.value)), x)
             end
         end
         ZygoteRules.@adjoint function Distributions.logpdf(
@@ -414,7 +414,7 @@ for T in (:AbstractVector, :AbstractMatrix)
             x::$T
         )
             return ZygoteRules.pullback(d, x) do d, x
-                logpdf(TuringDiagMvNormal(d.μ, d.Σ.diag), x)
+                logpdf(TuringDiagMvNormal(d.μ, sqrt.(d.Σ.diag)), x)
             end
         end
         ZygoteRules.@adjoint function Distributions.logpdf(
@@ -431,7 +431,9 @@ for T in (:AbstractVector, :AbstractMatrix)
             x::$T
         )
             return ZygoteRules.pullback(d, x) do d, x
-                dist = TuringMvLogNormal(TuringScalMvNormal(d.normal.μ, d.normal.Σ.value))
+                dist = TuringMvLogNormal(
+                    TuringScalMvNormal(d.normal.μ, sqrt(d.normal.Σ.value)),
+                )
                 logpdf(dist, x)
             end
         end
@@ -440,7 +442,9 @@ for T in (:AbstractVector, :AbstractMatrix)
             x::$T
         )
             return ZygoteRules.pullback(d, x) do d, x
-                dist = TuringMvLogNormal(TuringDiagMvNormal(d.normal.μ, d.normal.Σ.diag))
+                dist = TuringMvLogNormal(
+                    TuringDiagMvNormal(d.normal.μ, sqrt.(d.normal.Σ.diag)),
+                )
                 logpdf(dist, x)
             end
         end

--- a/src/reversediff.jl
+++ b/src/reversediff.jl
@@ -74,20 +74,20 @@ end
 for T in (:TrackedVector, :TrackedMatrix)
     @eval begin
         function logpdf(d::MvNormal{<:Any, <:PDMats.ScalMat}, x::$T)
-            logpdf(TuringScalMvNormal(d.μ, d.Σ.value), x)
+            logpdf(TuringScalMvNormal(d.μ, sqrt(d.Σ.value)), x)
         end
         function logpdf(d::MvNormal{<:Any, <:PDMats.PDiagMat}, x::$T)
-            logpdf(TuringDiagMvNormal(d.μ, d.Σ.diag), x)
+            logpdf(TuringDiagMvNormal(d.μ, sqrt.(d.Σ.diag)), x)
         end
         function logpdf(d::MvNormal{<:Any, <:PDMats.PDMat}, x::$T)
             logpdf(TuringDenseMvNormal(d.μ, d.Σ.chol), x)
         end
         
         function logpdf(d::MvLogNormal{<:Any, <:PDMats.ScalMat}, x::$T)
-            logpdf(TuringMvLogNormal(TuringScalMvNormal(d.normal.μ, d.normal.Σ.value)), x)
+            logpdf(TuringMvLogNormal(TuringScalMvNormal(d.normal.μ, sqrt(d.normal.Σ.value))), x)
         end
         function logpdf(d::MvLogNormal{<:Any, <:PDMats.PDiagMat}, x::$T)
-            logpdf(TuringMvLogNormal(TuringDiagMvNormal(d.normal.μ, d.normal.Σ.diag)), x)
+            logpdf(TuringMvLogNormal(TuringDiagMvNormal(d.normal.μ, sqrt.(d.normal.Σ.diag))), x)
         end
         function logpdf(d::MvLogNormal{<:Any, <:PDMats.PDMat}, x::$T)
             logpdf(TuringMvLogNormal(TuringDenseMvNormal(d.normal.μ, d.normal.Σ.chol)), x)

--- a/test/ad/utils.jl
+++ b/test/ad/utils.jl
@@ -2,7 +2,7 @@
 const AD = get(ENV, "AD", "All")
 
 # Struct of distribution, corresponding parameters, and a sample.
-struct DistSpec{VF <: VariateForm,VS <: ValueSupport,F,T,X,G}
+struct DistSpec{VF<:VariateForm,VS<:ValueSupport,F,T,X,G}
     name::Symbol
     f::F
     "Distribution parameters."
@@ -92,7 +92,7 @@ function test_ad(dist::DistSpec; kwargs...)
     g = dist.xtrans
 
     # Create function with all possible arguments
-    f_allargs = let f = f, g = g
+    f_allargs = let f=f, g=g
         function (x, θ...)
             dist = f(θ...)
             xtilde = g === nothing ? x : g(x)
@@ -112,8 +112,8 @@ function test_ad(dist::DistSpec; kwargs...)
             xtest = mapreduce(vcat, inds) do i
                 vectorize(θ[i - 1])
             end
-            ftest = let xorig = x, θorig = θ, inds = inds
-                x->f_allargs(unpack(x, inds, xorig, θorig...)...)
+            ftest = let xorig=x, θorig=θ, inds=inds
+                x -> f_allargs(unpack(x, inds, xorig, θorig...)...)
             end
             test_ad(ftest, xtest; kwargs...)
         end
@@ -123,33 +123,33 @@ function test_ad(dist::DistSpec; kwargs...)
         if Distributions.value_support(typeof(dist)) === Continuous
             xtest = isempty(inds) ? vectorize(x) : vcat(vectorize(x), xtest)
             push!(inds, 1)
-            ftest = let xorig = x, θorig = θ, inds = inds
-                x->f_allargs(unpack(x, inds, xorig, θorig...)...)
+            ftest = let xorig=x, θorig=θ, inds=inds
+                x -> f_allargs(unpack(x, inds, xorig, θorig...)...)
             end
             test_ad(ftest, xtest; kwargs...)
         end
     end
 end
 
-function test_ad(f, x; rtol=1e-6, atol=1e-6)
+function test_ad(f, x; rtol = 1e-6, atol = 1e-6)
     finitediff = FDM.grad(central_fdm(5, 1), f, x)[1]
 
     if AD == "All" || AD == "ForwardDiff_Tracker"
         tracker = Tracker.data(Tracker.gradient(f, x)[1])
-        @test tracker ≈ finitediff rtol = rtol atol = atol
+        @test tracker ≈ finitediff rtol=rtol atol=atol
 
         forward = ForwardDiff.gradient(f, x)
-        @test forward ≈ finitediff rtol = rtol atol = atol
+        @test forward ≈ finitediff rtol=rtol atol=atol
     end
 
     if AD == "All" || AD == "Zygote"
         zygote = Zygote.gradient(f, x)[1]
-        @test zygote ≈ finitediff rtol = rtol atol = atol
+        @test zygote ≈ finitediff rtol=rtol atol=atol
     end
 
     if AD == "All" || AD == "ReverseDiff"
         reversediff = ReverseDiff.gradient(f, x)
-        @test reversediff ≈ finitediff rtol = rtol atol = atol
+        @test reversediff ≈ finitediff rtol=rtol atol=atol
     end
 
     return

--- a/test/ad/utils.jl
+++ b/test/ad/utils.jl
@@ -2,7 +2,7 @@
 const AD = get(ENV, "AD", "All")
 
 # Struct of distribution, corresponding parameters, and a sample.
-struct DistSpec{VF<:VariateForm,VS<:ValueSupport,F,T,X,G}
+struct DistSpec{VF <: VariateForm,VS <: ValueSupport,F,T,X,G}
     name::Symbol
     f::F
     "Distribution parameters."
@@ -92,7 +92,7 @@ function test_ad(dist::DistSpec; kwargs...)
     g = dist.xtrans
 
     # Create function with all possible arguments
-    f_allargs = let f=f, g=g
+    f_allargs = let f = f, g = g
         function (x, θ...)
             dist = f(θ...)
             xtilde = g === nothing ? x : g(x)
@@ -105,58 +105,51 @@ function test_ad(dist::DistSpec; kwargs...)
         end
     end
 
-    if isempty(θ)
-        # In this case we can only test the gradient with respect to `x`
-        xtest = vectorize(x)
-        ftest = let xorig=x
-            x -> f_allargs(unpack(x, (1,), xorig)...)
-        end
-        test_ad(ftest, xtest; kwargs...)
-    else
-        # For all combinations of distribution parameters `θ`
-        for inds in combinations(2:(length(θ) + 1))
-            # Test only distribution parameters
+    # For all combinations of distribution parameters `θ`
+    for inds in powerset(2:(length(θ) + 1))
+        # Test only distribution parameters
+        if !isempty(inds)
             xtest = mapreduce(vcat, inds) do i
                 vectorize(θ[i - 1])
             end
-            ftest = let xorig=x, θorig=θ, inds=inds
-                x -> f_allargs(unpack(x, inds, xorig, θorig...)...)
+            ftest = let xorig = x, θorig = θ, inds = inds
+                x->f_allargs(unpack(x, inds, xorig, θorig...)...)
             end
             test_ad(ftest, xtest; kwargs...)
+        end
 
-            # Test derivative with respect to location `x` as well
-            # if the distribution is continuous
-            if Distributions.value_support(typeof(dist)) === Continuous
-                xtest = vcat(vectorize(x), xtest)
-                push!(inds, 1)
-                ftest = let xorig=x, θorig=θ, inds=inds
-                    x -> f_allargs(unpack(x, inds, xorig, θorig...)...)
-                end
-                test_ad(ftest, xtest; kwargs...)
+        # Test derivative with respect to location `x` as well
+        # if the distribution is continuous
+        if Distributions.value_support(typeof(dist)) === Continuous
+            xtest = isempty(inds) ? vectorize(x) : vcat(vectorize(x), xtest)
+            push!(inds, 1)
+            ftest = let xorig = x, θorig = θ, inds = inds
+                x->f_allargs(unpack(x, inds, xorig, θorig...)...)
             end
+            test_ad(ftest, xtest; kwargs...)
         end
     end
 end
 
-function test_ad(f, x; rtol = 1e-6, atol = 1e-6)
+function test_ad(f, x; rtol=1e-6, atol=1e-6)
     finitediff = FDM.grad(central_fdm(5, 1), f, x)[1]
 
     if AD == "All" || AD == "ForwardDiff_Tracker"
         tracker = Tracker.data(Tracker.gradient(f, x)[1])
-        @test tracker ≈ finitediff rtol=rtol atol=atol
+        @test tracker ≈ finitediff rtol = rtol atol = atol
 
         forward = ForwardDiff.gradient(f, x)
-        @test forward ≈ finitediff rtol=rtol atol=atol
+        @test forward ≈ finitediff rtol = rtol atol = atol
     end
 
     if AD == "All" || AD == "Zygote"
         zygote = Zygote.gradient(f, x)[1]
-        @test zygote ≈ finitediff rtol=rtol atol=atol
+        @test zygote ≈ finitediff rtol = rtol atol = atol
     end
 
     if AD == "All" || AD == "ReverseDiff"
         reversediff = ReverseDiff.gradient(f, x)
-        @test reversediff ≈ finitediff rtol=rtol atol=atol
+        @test reversediff ≈ finitediff rtol = rtol atol = atol
     end
 
     return


### PR DESCRIPTION
@mohamed82008 noticed that both the previous and the updated test sets (the logic was unchanged) don't test AD with respect to samples `x` and fixed distribution parameters `theta` if `theta` is not empty (only the case when `theta` was empty was covered). This PR adds these additional tests.

Actually, in my local runs some of these tests seem to be broken (see, e.g., https://github.com/TuringLang/DistributionsAD.jl/issues/91) and fail currently. I'm a bit surprised that this hasn't shown up in the other tests with at least one non-fixed distribution parameter.

Somehow the automatic code formatting in VSCode introduced some additional changes...