### PR TITLE
WIP test broken backends

### DIFF
--- a/test/ad/distributions.jl
+++ b/test/ad/distributions.jl
@@ -425,10 +425,22 @@
 
                 # Test AD
                 test_ad(
-                    DistSpec(Symbol(:filldist, " (", d.name, ", $sz)"), f_filldist, d.θ, x)
+                    DistSpec(
+                        Symbol(:filldist, " (", d.name, ", $sz)"),
+                        f_filldist,
+                        d.θ,
+                        x;
+                        broken=d.broken,
+                    )
                 )
                 test_ad(
-                    DistSpec(Symbol(:arraydist, " (", d.name, ", $sz)"), f_arraydist, d.θ, x)
+                    DistSpec(
+                        Symbol(:arraydist, " (", d.name, ", $sz)"),
+                        f_arraydist,
+                        d.θ,
+                        x;
+                        broken=d.broken,
+                    )
                 )
             end
         end
@@ -461,10 +473,22 @@
 
             # Test AD
             test_ad(
-                DistSpec(Symbol(:filldist, " (", d.name, ", $n)"), f_filldist, d.θ, x_mat)
+                DistSpec(
+                    Symbol(:filldist, " (", d.name, ", $n)"),
+                    f_filldist,
+                    d.θ,
+                    x_mat;
+                    broken=d.broken,
+                )
             )
             test_ad(
-                DistSpec(Symbol(:arraydist, " (", d.name, ", $n)"), f_arraydist, d.θ, x_mat)
+                DistSpec(
+                    Symbol(:arraydist, " (", d.name, ", $n)"),
+                    f_arraydist,
+                    d.θ,
+                    x_mat;
+                    broken=d.broken,
+                )
             )
 
             # Vector of matrices `x`
@@ -476,7 +500,8 @@
                     Symbol(:filldist, " (", d.name, ", $n, 2)"),
                     f_filldist,
                     d.θ,
-                    x_vec_of_mat,
+                    x_vec_of_mat;
+                    broken=d.broken,
                 )
             )
             test_ad(
@@ -484,7 +509,8 @@
                     Symbol(:arraydist, " (", d.name, ", $n, 2)"),
                     f_arraydist,
                     d.θ,
-                    x_vec_of_mat,
+                    x_vec_of_mat;
+                    broken=d.broken,
                 )
             )
         end
@@ -518,10 +544,22 @@
 
             # Test AD
             test_ad(
-                DistSpec(Symbol(:filldist, " (", d.name, ", $n)"), f_filldist, d.θ, x_mat)
+                DistSpec(
+                    Symbol(:filldist, " (", d.name, ", $n)"),
+                    f_filldist,
+                    d.θ,
+                    x_mat;
+                    broken=d.broken,
+                )
             )
             test_ad(
-                DistSpec(Symbol(:arraydist, " (", d.name, ", $n)"), f_arraydist, d.θ, x_mat)
+                DistSpec(
+                    Symbol(:arraydist, " (", d.name, ", $n)"),
+                    f_arraydist,
+                    d.θ,
+                    x_mat;
+                    broken=d.broken,
+                )
             )
 
             # Vector of matrices `x`
@@ -533,7 +571,8 @@
                     Symbol(:filldist, " (", d.name, ", $n, 2)"),
                     f_filldist,
                     d.θ,
-                    x_vec_of_mat,
+                    x_vec_of_mat;
+                    broken=d.broken,
                 )
             )
             test_ad(
@@ -541,7 +580,8 @@
                     Symbol(:arraydist, " (", d.name, ", $n, 2)"),
                     f_arraydist,
                     d.θ,
-                    x_vec_of_mat,
+                    x_vec_of_mat;
+                    broken=d.broken,
                 )
             )
         end

--- a/test/ad/distributions.jl
+++ b/test/ad/distributions.jl
@@ -240,6 +240,9 @@
 
         # Vector x
         DistSpec(p -> Multinomial(2, p ./ sum(p)), (fill(0.5, 2),), [2, 0]),
+        DistSpec(p -> Multinomial(2, p ./ sum(p)), (fill(0.5, 2),), [2 1; 0 1],
+            broken=(:Tracker, :Zygote),
+        )
 
         # Vector x
         DistSpec((m, A) -> MvNormal(m, to_posdef(A)), (a, A), b),
@@ -293,8 +296,8 @@
         DistSpec(alpha -> Dirichlet(to_positive(alpha)), (a,), A, to_simplex),
     ]
 
+    # These methods are so broken that they cannot be tested with `@test_broken`
     broken_multivariate_distributions = DistSpec[
-        DistSpec(p -> Multinomial(2, p ./ sum(p)), (fill(0.5, 2),), [2 1; 0 1]),
         # Dispatch error
         DistSpec((m, A) -> MvNormalCanon(m, to_posdef(A)), (a, A), b),
         DistSpec(MvNormalCanon, (a, b), c),

--- a/test/ad/distributions.jl
+++ b/test/ad/distributions.jl
@@ -316,6 +316,9 @@
     matrixvariate_distributions = DistSpec[
         # Matrix x
         DistSpec((n1, n2) -> MatrixBeta(dim, n1, n2), (3.0, 3.0), A, to_beta_mat),
+        DistSpec(() -> MatrixNormal(dim, dim), (), A, to_posdef,
+            broken=(:Tracker, :Zygote)
+        ),
         DistSpec((df, A) -> Wishart(df, to_posdef(A)), (3.0, A), B, to_posdef),
         DistSpec((df, A) -> InverseWishart(df, to_posdef(A)), (3.0, A), B, to_posdef),
         DistSpec((df, A) -> TuringWishart(df, to_posdef(A)), (3.0, A), B, to_posdef),
@@ -356,19 +359,21 @@
 
     broken_matrixvariate_distributions = DistSpec[
         # Other
+        # TODO different tests are broken on different combinations of backends
         DistSpec(
             (A, B, C) -> MatrixNormal(A, to_posdef(B), to_posdef(C)),
             (A, B, B),
             C,
             to_posdef,
         ),
-        DistSpec(() -> MatrixNormal(dim, dim), (), A, to_posdef),
+        # TODO different tests are broken on different combinations of backends
         DistSpec(
             (df, A, B, C) -> MatrixTDist(df, A, to_posdef(B), to_posdef(C)),
             (1.0, A, B, B),
             C,
             to_posdef,
         ),
+        # TODO different tests are broken on different combinations of backends
         DistSpec(
             (n1, n2, A) -> MatrixFDist(n1, n2, to_posdef(A)),
             (3.0, 3.0, A),

--- a/test/ad/distributions.jl
+++ b/test/ad/distributions.jl
@@ -103,6 +103,8 @@
         DistSpec(Cauchy, (1.0,), 0.5),
         DistSpec(Cauchy, (1.0, 2.0), 0.5),
 
+        DistSpec(Chernoff, (), 0.5, broken=(:Zygote)),
+
         DistSpec(Chi, (1.0,), 0.5),
 
         DistSpec(Chisq, (1.0,), 0.5),
@@ -167,6 +169,12 @@
         DistSpec(LogNormal, (1.0,), 0.5),
         DistSpec(LogNormal, (1.0, 2.0), 0.5),
 
+        # Dispatch error caused by ccall
+        DistSpec(NoncentralBeta, (1.0, 2.0, 1.0), 0.5, broken=(:Tracker, :ForwardDiff, :Zygote, :ReverseDiff)),
+        DistSpec(NoncentralChisq, (1.0, 2.0), 0.5, broken=(:Tracker, :ForwardDiff, :Zygote, :ReverseDiff)),
+        DistSpec(NoncentralF, (1, 2, 1), 0.5, broken=(:Tracker, :ForwardDiff, :Zygote, :ReverseDiff)),
+        DistSpec(NoncentralT, (1, 2), 0.5, broken=(:Tracker, :ForwardDiff, :Zygote, :ReverseDiff)),
+
         DistSpec(Normal, (), 0.5),
         DistSpec(Normal, (1.0,), 0.5),
         DistSpec(Normal, (1.0, 2.0), 0.5),
@@ -215,20 +223,12 @@
         DistSpec(Weibull, (1.0, 1.0), 1.0),
     ]
 
+    # These methods are so broken that they cannot be tested with `@test_broken`
     broken_univariate_distributions = DistSpec[
-        # Zygote
-        DistSpec(Chernoff, (), 0.5),
-
         # Broken in Distributions even without autodiff
-        DistSpec(() -> KSDist(1), (), 0.5),
-        DistSpec(() -> KSOneSided(1), (), 0.5),
-        DistSpec(StudentizedRange, (1.0, 2.0), 0.5),
-
-        # Dispatch error caused by ccall
-        DistSpec(NoncentralBeta, (1.0, 2.0, 1.0), 0.5),
-        DistSpec(NoncentralChisq, (1.0, 2.0), 0.5),
-        DistSpec(NoncentralF, (1, 2, 1), 0.5),
-        DistSpec(NoncentralT, (1, 2), 0.5),
+        DistSpec(() -> KSDist(1), (), 0.5), # `pdf` method not defined
+        DistSpec(() -> KSOneSided(1), (), 0.5), # `pdf` method not defined
+        DistSpec(StudentizedRange, (1.0, 2.0), 0.5), # `srdistlogpdf` method not defined
 
         # Stackoverflow caused by SpecialFunctions.besselix
         DistSpec(VonMises, (1.0,), 1.0),

--- a/test/ad/distributions.jl
+++ b/test/ad/distributions.jl
@@ -172,8 +172,8 @@
         # Dispatch error caused by ccall
         DistSpec(NoncentralBeta, (1.0, 2.0, 1.0), 0.5, broken=(:Tracker, :ForwardDiff, :Zygote, :ReverseDiff)),
         DistSpec(NoncentralChisq, (1.0, 2.0), 0.5, broken=(:Tracker, :ForwardDiff, :Zygote, :ReverseDiff)),
-        DistSpec(NoncentralF, (1, 2, 1), 0.5, broken=(:Tracker, :ForwardDiff, :Zygote, :ReverseDiff)),
-        DistSpec(NoncentralT, (1, 2), 0.5, broken=(:Tracker, :ForwardDiff, :Zygote, :ReverseDiff)),
+        DistSpec(NoncentralF, (1.0, 2.0, 1.0), 0.5, broken=(:Tracker, :ForwardDiff, :Zygote, :ReverseDiff)),
+        DistSpec(NoncentralT, (1.0, 2.0), 0.5, broken=(:Tracker, :ForwardDiff, :Zygote, :ReverseDiff)),
 
         DistSpec(Normal, (), 0.5),
         DistSpec(Normal, (1.0,), 0.5),

--- a/test/ad/distributions.jl
+++ b/test/ad/distributions.jl
@@ -103,7 +103,7 @@
         DistSpec(Cauchy, (1.0,), 0.5),
         DistSpec(Cauchy, (1.0, 2.0), 0.5),
 
-        DistSpec(Chernoff, (), 0.5, broken=(:Zygote)),
+        DistSpec(Chernoff, (), 0.5, broken=(:Zygote,)),
 
         DistSpec(Chi, (1.0,), 0.5),
 

--- a/test/ad/distributions.jl
+++ b/test/ad/distributions.jl
@@ -46,6 +46,8 @@
         return y ./ sum(y, dims=dims)
     end
 
+    # Tests that have a `broken` field can be executed but, according to FiniteDifferences,
+    # fail to produce the correct result. These tests can be checked with `@test_broken`.
     univariate_distributions = DistSpec[
         ## Univariate discrete distributions
 
@@ -223,7 +225,7 @@
         DistSpec(Weibull, (1.0, 1.0), 1.0),
     ]
 
-    # These methods are so broken that they cannot be tested with `@test_broken`
+    # Tests cannot be executed, so cannot be checked with `@test_broken`.
     broken_univariate_distributions = DistSpec[
         # Broken in Distributions even without autodiff
         DistSpec(() -> KSDist(1), (), 0.5), # `pdf` method not defined
@@ -235,6 +237,8 @@
         DistSpec(VonMises, (1, 1), 1),
     ]
 
+    # Tests that have a `broken` field can be executed but, according to FiniteDifferences,
+    # fail to produce the correct result. These tests can be checked with `@test_broken`.
     multivariate_distributions = DistSpec[
         ## Multivariate discrete distributions
 
@@ -296,7 +300,7 @@
         DistSpec(alpha -> Dirichlet(to_positive(alpha)), (a,), A, to_simplex),
     ]
 
-    # These methods are so broken that they cannot be tested with `@test_broken`
+    # Tests cannot be executed, so cannot be checked with `@test_broken`.
     broken_multivariate_distributions = DistSpec[
         # Dispatch error
         DistSpec((m, A) -> MvNormalCanon(m, to_posdef(A)), (a, A), b),
@@ -313,6 +317,8 @@
         DistSpec(s -> MvNormalCanon(dim, s), (alpha,), A),
     ]
 
+    # Tests that have a `broken` field can be executed but, according to FiniteDifferences,
+    # fail to produce the correct result. These tests can be checked with `@test_broken`.
     matrixvariate_distributions = DistSpec[
         # Matrix x
         DistSpec((n1, n2) -> MatrixBeta(dim, n1, n2), (3.0, 3.0), A, to_beta_mat),
@@ -357,6 +363,7 @@
         ),
     ]
 
+    # Tests cannot be executed, so cannot be checked with `@test_broken`.
     broken_matrixvariate_distributions = DistSpec[
         # Other
         # TODO different tests are broken on different combinations of backends

--- a/test/ad/distributions.jl
+++ b/test/ad/distributions.jl
@@ -242,7 +242,7 @@
         DistSpec(p -> Multinomial(2, p ./ sum(p)), (fill(0.5, 2),), [2, 0]),
         DistSpec(p -> Multinomial(2, p ./ sum(p)), (fill(0.5, 2),), [2 1; 0 1],
             broken=(:Tracker, :Zygote),
-        )
+        ),
 
         # Vector x
         DistSpec((m, A) -> MvNormal(m, to_posdef(A)), (a, A), b),

--- a/test/ad/utils.jl
+++ b/test/ad/utils.jl
@@ -118,7 +118,7 @@ function test_ad(dist::DistSpec; kwargs...)
             ftest = let xorig=x, θorig=θ, inds=inds
                 x -> f_allargs(unpack(x, inds, xorig, θorig...)...)
             end
-            test_ad(ftest, xtest; kwargs...)
+            test_ad(ftest, xtest, broken; kwargs...)
         end
 
         # Test derivative with respect to location `x` as well
@@ -129,7 +129,7 @@ function test_ad(dist::DistSpec; kwargs...)
             ftest = let xorig=x, θorig=θ, inds=inds
                 x -> f_allargs(unpack(x, inds, xorig, θorig...)...)
             end
-            test_ad(ftest, xtest; kwargs...)
+            test_ad(ftest, xtest, broken; kwargs...)
         end
     end
 end


### PR DESCRIPTION
I have just been looking into how to test whether particular backends are broken using `@test_broken`. If this looks good to @devmotion, I can have a go at adding the relevant broken backends to the broken tests.

Ref #93 and https://github.com/TuringLang/Bijectors.jl/pull/116#discussion_r443399529

Example on a randomly chosen broken test:

```julia
julia> d = DistSpec(
           p -> Multinomial(2, p ./ sum(p)),
           (fill(0.5, 2),),
           [2 1; 0 1],
           broken=("Tracker", "Zygote"),
       );

julia> test_ad(d)
[ Info: Testing: Multinomial

julia> d = DistSpec(
           p -> Multinomial(2, p ./ sum(p)),
           (fill(0.5, 2),),
           [2 1; 0 1],
       );

julia> test_ad(d)
[ Info: Testing: Multinomial
Error During Test at /Users/harry/git/julia_sandbox/tmp.jl:213
  Test threw exception
  Expression: ≈(Tracker.data((Tracker.gradient(f, x))[1]), finitediff, rtol = rtol, atol = atol)
  MethodError: no method matching Float64(::Tracker.TrackedReal{Float64})
  Closest candidates are:
    Float64(::Real, !Matched::RoundingMode) where T<:AbstractFloat at rounding.jl:200
    Float64(::T) where T<:Number at boot.jl:715
    Float64(!Matched::Int8) at float.jl:60
    ...
  Stacktrace:
   [1] convert(::Type{Float64}, ::Tracker.TrackedReal{Float64}) at ./number.jl:7
   [2] setindex!(::Array{Float64,1}, ::Tracker.TrackedReal{Float64}, ::Int64) at ./array.jl:826
   [3] _logpdf! at /Users/harry/.julia/packages/Distributions/RAeyY/src/multivariates.jl:206 [inlined]
   [4] logpdf(::Multinomial{Float64,TrackedArray{…,Array{Float64,1}}}, ::Array{Int64,2}) at /Users/harry/.julia/packages/Distributions/RAeyY/src/multivariates.jl:234
   [5] (::Main.Tmp.var"#85#90"{Main.Tmp.var"#156#157",Nothing})(::Array{Int64,2}, ::TrackedArray{…,Array{Float64,1}}) at /Users/harry/git/julia_sandbox/tmp.jl:167
   [6] (::Main.Tmp.var"#88#93"{Main.Tmp.var"#85#90"{Main.Tmp.var"#156#157",Nothing},Array{Int64,2},Tuple{Array{Float64,1}},Array{Int64,1}})(::TrackedArray{…,Array{Float64,1}}) at /Users/harry/git/julia_sandbox/tmp.jl:188
   [7] gradient_(::Function, ::Array{Float64,1}) at /Users/harry/.julia/packages/Tracker/27b5Q/src/back.jl:90
   [8] #gradient#24 at /Users/harry/.julia/packages/Tracker/27b5Q/src/back.jl:164 [inlined]
   [9] gradient at /Users/harry/.julia/packages/Tracker/27b5Q/src/back.jl:164 [inlined]
   [10] test_ad(::Function, ::Array{Float64,1}, ::Tuple{}; rtol::Float64, atol::Float64) at /Users/harry/git/julia_sandbox/tmp.jl:213
   [11] test_ad(::Function, ::Array{Float64,1}, ::Tuple{}) at /Users/harry/git/julia_sandbox/tmp.jl:207
   [12] test_ad(::Main.Tmp.DistSpec{Multivariate,Discrete,Main.Tmp.var"#156#157",Tuple{Array{Float64,1}},Array{Int64,2},Nothing}; kwargs::Base.Iterators.Pairs{Union{},Union{},Tuple{},NamedTuple{(),Tuple{}}}) at /Users/harry/git/julia_sandbox/tmp.jl:190
   [13] test_ad(::Main.Tmp.DistSpec{Multivariate,Discrete,Main.Tmp.var"#156#157",Tuple{Array{Float64,1}},Array{Int64,2},Nothing}) at /Users/harry/git/julia_sandbox/tmp.jl:151
   [14] top-level scope at none:0
   [15] eval at ./boot.jl:331 [inlined]
   [16] repleval(::Module, ::Expr) at /Users/harry/.julia/packages/Atom/8MnXm/src/repl.jl:196
   [17] (::Atom.var"#246#248"{Module})() at /Users/harry/.julia/packages/Atom/8MnXm/src/repl.jl:223
   [18] with_logstate(::Atom.var"#246#248"{Module}, ::Base.CoreLogging.LogState) at ./logging.jl:398
   [19] with_logger at ./logging.jl:505 [inlined]
   [20] evalrepl(::Module, ::String) at /Users/harry/.julia/packages/Atom/8MnXm/src/repl.jl:214
   [21] top-level scope at /Users/harry/.julia/packages/Atom/8MnXm/src/repl.jl:259
   [22] eval(::Module, ::Any) at ./boot.jl:331
   [23] eval_user_input(::Any, ::REPL.REPLBackend) at /Users/julia/buildbot/worker/package_macos64/build/usr/share/julia/stdlib/v1.4/REPL/src/REPL.jl:86
   [24] macro expansion at /Users/julia/buildbot/worker/package_macos64/build/usr/share/julia/stdlib/v1.4/REPL/src/REPL.jl:118 [inlined]
   [25] (::REPL.var"#26#27"{REPL.REPLBackend})() at ./task.jl:358
  
ERROR: There was an error during testing

```