### PR TITLE
Remove some custom adjoints

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "DistributionsAD"
 uuid = "ced4e74d-a319-5a8a-b0ac-84af2272839c"
-version = "0.6.3"
+version = "0.6.4"
 
 [deps]
 ChainRules = "082447d4-558c-5d27-93f4-14fc19e9eca2"

--- a/src/arraydist.jl
+++ b/src/arraydist.jl
@@ -5,7 +5,8 @@ function summaporbroadcast(f, dists::AbstractArray, x::AbstractArray)
     return sum(map(f, dists, x))
 end
 function summaporbroadcast(f, dists::AbstractVector, x::AbstractMatrix)
-    return map(x -> summaporbroadcast(f, dists, x), eachcol(x))
+    # `eachcol` breaks Zygote, so we use `view` directly
+    return map(i -> summaporbroadcast(f, dists, view(x, :, i)), axes(x, 2))
 end
 @init @require LazyArrays = "5078a376-72f3-5289-bfd5-ec5146d43c02" begin
     function summaporbroadcast(f, dists::LazyArrays.BroadcastArray, x::AbstractArray)
@@ -32,14 +33,6 @@ end
 function Distributions.logpdf(dist::VectorOfUnivariate, x::AbstractMatrix{<:Real})
     # eachcol breaks Zygote, so we need an adjoint
     return summaporbroadcast(logpdf, dist.v, x)
-end
-ZygoteRules.@adjoint function Distributions.logpdf(
-    dist::VectorOfUnivariate,
-    x::AbstractMatrix{<:Real}
-)
-    # Any other more efficient implementation breaks Zygote
-    f(dist, x) = [sum(logpdf.(dist.v, view(x, :, i))) for i in 1:size(x, 2)]
-    return ZygoteRules.pullback(f, dist, x)
 end
 
 struct MatrixOfUnivariate{
@@ -80,9 +73,10 @@ Base.length(dist::VectorOfMultivariate) = length(dist.dists)
 function arraydist(dists::AbstractVector{<:MultivariateDistribution})
     return VectorOfMultivariate(dists)
 end
+
 function Distributions.logpdf(dist::VectorOfMultivariate, x::AbstractMatrix{<:Real})
-    # eachcol breaks Zygote, so we define an adjoint
-    return sum(map(logpdf, dist.dists, eachcol(x)))
+    # `eachcol` breaks Zygote, so we use `view` directly
+    return sum(map(logpdf, dist.dists, axes(x, 2)))
 end
 function Distributions.logpdf(dist::VectorOfMultivariate, x::AbstractArray{<:AbstractMatrix{<:Real}})
     return map(x -> logpdf(dist, x), x)
@@ -90,14 +84,7 @@ end
 function Distributions.logpdf(dist::VectorOfMultivariate, x::AbstractArray{<:Matrix{<:Real}})
     return map(x -> logpdf(dist, x), x)
 end
-ZygoteRules.@adjoint function Distributions.logpdf(
-    dist::VectorOfMultivariate,
-    x::AbstractMatrix{<:Real}
-)
-    return ZygoteRules.pullback(dist, x) do dist, x
-        sum(map(i -> logpdf(dist.dists[i], view(x, :, i)), 1:size(x, 2)))
-    end
-end
+
 function Distributions.rand(rng::Random.AbstractRNG, dist::VectorOfMultivariate)
     init = reshape(rand(rng, dist.dists[1]), :, 1)
     return mapreduce(i -> rand(rng, dist.dists[i]), hcat, 2:length(dist); init = init)

--- a/src/filldist.jl
+++ b/src/filldist.jl
@@ -23,12 +23,6 @@ function Distributions.logpdf(
 )
     return _logpdf(dist, x)
 end
-ZygoteRules.@adjoint function Distributions.logpdf(
-    dist::FillVectorOfUnivariate,
-    x::AbstractMatrix{<:Real},
-)
-    return ZygoteRules.pullback(_logpdf, dist, x)
-end
 
 function _logpdf(
     dist::FillVectorOfUnivariate,
@@ -103,18 +97,14 @@ function Distributions.logpdf(
 )
     return _logpdf(dist, x)
 end
+
 function _logpdf(
     dist::FillVectorOfMultivariate,
     x::AbstractMatrix{<:Real},
 )
     return sum(logpdf(dist.dists.value, x))
 end
-ZygoteRules.@adjoint function Distributions.logpdf(
-    dist::FillVectorOfMultivariate,
-    x::AbstractMatrix{<:Real},
-)
-    return ZygoteRules.pullback(_logpdf, dist, x)
-end
+
 function Distributions.rand(rng::Random.AbstractRNG, dist::FillVectorOfMultivariate)
     return rand(rng, dist.dists.value, length.(dist.dists.axes)...,)
 end

--- a/src/multivariate.jl
+++ b/src/multivariate.jl
@@ -10,9 +10,7 @@ function check(alpha)
     all(ai -> ai > 0, alpha) || 
         throw(ArgumentError("Dirichlet: alpha must be a positive vector."))
 end
-ZygoteRules.@adjoint function check(alpha)
-    return check(alpha), _ -> (nothing,)
-end
+
 function Distributions._rand!(rng::Random.AbstractRNG,
                 d::TuringDirichlet,
                 x::AbstractVector{<:Real})


### PR DESCRIPTION
While working on https://github.com/TuringLang/DistributionsAD.jl/pull/103, I noticed that some custom adjoints are not needed anymore it seems.