### PR TITLE
Require Julia 1.3

### DIFF
--- a/.github/workflows/ForwardDiff.yml
+++ b/.github/workflows/ForwardDiff.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         version:
-          - '1.0'
+          - '1.3'
           - '1'
         os:
           - ubuntu-latest

--- a/.github/workflows/Others.yml
+++ b/.github/workflows/Others.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         version:
-          - '1.0'
+          - '1.3'
           - '1'
         os:
           - ubuntu-latest

--- a/.github/workflows/ReverseDiff.yml
+++ b/.github/workflows/ReverseDiff.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         version:
-          - '1.0'
+          - '1.3'
           - '1'
         os:
           - ubuntu-latest

--- a/.github/workflows/Tracker.yml
+++ b/.github/workflows/Tracker.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         version:
-          - '1.0'
+          - '1.3'
           - '1'
         os:
           - ubuntu-latest

--- a/.github/workflows/Zygote.yml
+++ b/.github/workflows/Zygote.yml
@@ -12,6 +12,7 @@ jobs:
     strategy:
       matrix:
         version:
+          - '1.3'
           - '1'
         os:
           - ubuntu-latest

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "DistributionsAD"
 uuid = "ced4e74d-a319-5a8a-b0ac-84af2272839c"
-version = "0.6.3"
+version = "0.6.4"
 
 [deps]
 ChainRules = "082447d4-558c-5d27-93f4-14fc19e9eca2"
@@ -36,7 +36,7 @@ StaticArrays = "0.12"
 StatsBase = "0.32, 0.33"
 StatsFuns = "0.8, 0.9"
 ZygoteRules = "0.2"
-julia = "1"
+julia = "1.3"
 
 [extras]
 Combinatorics = "861a8166-3701-5b0c-9a16-15d98fcdc6aa"

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "DistributionsAD"
 uuid = "ced4e74d-a319-5a8a-b0ac-84af2272839c"
-version = "0.6.4"
+version = "0.6.3"
 
 [deps]
 ChainRules = "082447d4-558c-5d27-93f4-14fc19e9eca2"

--- a/test/ad/distributions.jl
+++ b/test/ad/distributions.jl
@@ -307,9 +307,7 @@
     matrixvariate_distributions = DistSpec[
         # Matrix x
         DistSpec((n1, n2) -> MatrixBeta(dim, n1, n2), (3.0, 3.0), A, to_beta_mat),
-        DistSpec(() -> MatrixNormal(dim, dim), (), A, to_posdef,
-            broken=(:Tracker, :Zygote)
-        ),
+        DistSpec(() -> MatrixNormal(dim, dim), (), A, to_posdef, broken=(:Zygote,)),
         DistSpec((df, A) -> Wishart(df, to_posdef(A)), (3.0, A), B, to_posdef),
         DistSpec((df, A) -> InverseWishart(df, to_posdef(A)), (3.0, A), B, to_posdef),
         DistSpec((df, A) -> TuringWishart(df, to_posdef(A)), (3.0, A), B, to_posdef),


### PR DESCRIPTION
Tracker issues related to PDMats 0.10 are fixed in the recent release of Tracker which, however, is not available on Julia < 1.3. To avoid having to backport fixes to earlier Julia versions, we drop support of Julia < 1.3 and add tests for Julia 1.3 (probably, waiting for more comments on https://discourse.julialang.org/t/rfc-dropping-support-for-julia-1-3-in-turing-jl/45015).