### PR TITLE
Fix `adapt_randn` for tracked arrays

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "DistributionsAD"
 uuid = "ced4e74d-a319-5a8a-b0ac-84af2272839c"
-version = "0.6.8"
+version = "0.6.9"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/src/common.jl
+++ b/src/common.jl
@@ -48,13 +48,13 @@ end
 # Tracker's implementation of ldiv isn't good. We'll use Zygote's instead.
 zygote_ldiv(A::AbstractMatrix, B::AbstractVecOrMat) = A \ B
 
-function adapt_randn(rng, x::AbstractArray, dims...)
+function adapt_randn(rng::AbstractRNG, x::AbstractArray, dims...)
     adapt(typeof(x), randn(rng, eltype(x), dims...))
 end
 
 # TODO: should be replaced by @non_differentiable when
 # https://github.com/JuliaDiff/ChainRulesCore.jl/issues/212 is fixed
-function ChainRules.rrule(::typeof(adapt_randn), rng, x, dims...)
+function ChainRules.rrule(::typeof(adapt_randn), rng::AbstractRNG, x::AbstractArray, dims...)
     function adapt_randn_pullback(ΔQ)
         return (NO_FIELDS, Zero(), Zero(), map(_ -> Zero(), dims)...)
     end

--- a/src/forwarddiff.jl
+++ b/src/forwarddiff.jl
@@ -1,3 +1,7 @@
+function adapt_randn(rng::AbstractRNG, x::AbstractArray{<:ForwardDiff.Dual}, dims...)
+    adapt(typeof(x), randn(rng, ForwardDiff.valtype(eltype(x)), dims...))
+end
+
 ## Binomial ##
 
 function binomlogpdf(n::Int, p::ForwardDiff.Dual{T}, x::Int) where {T}

--- a/src/reversediff.jl
+++ b/src/reversediff.jl
@@ -18,12 +18,14 @@ using ..DistributionsAD: DistributionsAD
 
 
 import SpecialFunctions, NaNMath
-import ..DistributionsAD: turing_chol, symm_turing_chol, _mv_categorical_logpdf
+import ..DistributionsAD: turing_chol, symm_turing_chol, _mv_categorical_logpdf, adapt_randn
 import Base.Broadcast: materialize
 import StatsFuns: logsumexp
 
 const TrackedVecOrMat{V,D} = Union{TrackedVector{V,D},TrackedMatrix{V,D}}
 const RDBroadcasted{F, T} = Broadcasted{<:Any, <:Any, F, T}
+
+import Random
 
 import Distributions: logpdf,
                       _logpdf,
@@ -48,6 +50,8 @@ using ..DistributionsAD: TuringPoissonBinomial,
                          TuringDenseMvNormal
 
 include("reversediffx.jl")
+
+adapt_randn(rng::Random.AbstractRNG, x::TrackedArray, dims...) = adapt_randn(rng, value(x), dims...)
 
 function PoissonBinomial(p::TrackedArray{<:Real}; check_args=true)
     return TuringPoissonBinomial(p; check_args = check_args)

--- a/src/tracker.jl
+++ b/src/tracker.jl
@@ -202,6 +202,9 @@ for f in (:+, :-, :*, :/, :\, :dot), (T1, T2) in [
     end
 end
 
+## `adapt_randn`
+
+adapt_randn(rng::AbstractRNG, x::TrackedArray, dims...) = adapt_randn(rng, data(x), dims...)
 
 ## Uniform ##
 


### PR DESCRIPTION
This PR fixes some of the test errors on Turing that are caused by `adapt_randn` (e.g., https://travis-ci.com/github/TuringLang/Turing.jl/jobs/383997198).