### PR TITLE
Adding an implementation of a mean-field MvNormal

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ version = "0.6.9"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
+BlockDiagonals = "0a1fb500-61f7-11e9-3c65-f5ef3456f9f0"
 ChainRules = "082447d4-558c-5d27-93f4-14fc19e9eca2"
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
@@ -24,6 +25,7 @@ ZygoteRules = "700de1a5-db45-46bc-99cf-38207098b444"
 
 [compat]
 Adapt = "2"
+BlockDiagonals = "0.1"
 ChainRules = "0.7"
 ChainRulesCore = "0.9.7"
 Compat = "3.6"

--- a/src/DistributionsAD.jl
+++ b/src/DistributionsAD.jl
@@ -19,6 +19,7 @@ using LinearAlgebra: copytri!, AbstractTriangular
 using Distributions: AbstractMvLogNormal, 
                      ContinuousMultivariateDistribution
 using Base.Iterators: drop
+using BlockDiagonals: BlockDiagonal
 
 import StatsBase
 import StatsFuns: logsumexp, 
@@ -39,6 +40,7 @@ import Distributions: MvNormal,
 export TuringScalMvNormal,
        TuringDiagMvNormal,
        TuringDenseMvNormal,
+       TuringMFMvNormal,
        TuringMvLogNormal,
        TuringPoissonBinomial,
        TuringWishart,

--- a/src/multivariate.jl
+++ b/src/multivariate.jl
@@ -113,7 +113,7 @@ end
 
 function TuringMFMvNormal(m::AbstractVector, A::AbstractVector{<:AbstractMatrix})
     length(m) == sum(size.(A, 1)) || error("Size between the mean and variance is not compatible")
-    return TuringMFMvNormal(m, BlockDiagonal(getproperty.(cholesky.(A), :U)), vcat(0, cumsum(size.(A, 1))))
+    return TuringMFMvNormal(m, BlockDiagonal(getproperty.(cholesky.(A), :U)))
 end
 Base.length(d::TuringMFMvNormal) = length(d.m)
 Distributions.rand(d::TuringMFMvNormal, n::Int...) = rand(Random.GLOBAL_RNG, d, n...)
@@ -225,6 +225,7 @@ TuringMvNormal(d::Int, σ::Real) = TuringMvNormal(zeros(d), σ)
 TuringMvNormal(m::AbstractVector{<:Real}, σ::Real) = TuringScalMvNormal(m, σ)
 TuringMvNormal(σ::AbstractVector) = TuringMvNormal(zeros(length(σ)), σ)
 TuringMvNormal(A::AbstractMatrix) = TuringMvNormal(zeros(size(A, 1)), A)
+TuringMvNormal(A::AbstractVector{<:AbstractMatrix}) = TuringMvNormal(zeros(sum(size.(A, 1))), A)
 function TuringMvNormal(m::AbstractVector{<:Real}, σ::AbstractVector{<:Real})
     return TuringDiagMvNormal(m, σ)
 end

--- a/test/ad/distributions.jl
+++ b/test/ad/distributions.jl
@@ -6,9 +6,13 @@
     a = rand(dim)
     b = rand(dim)
     c = rand(dim)
+    d = rand(2 * dim)
+    e = rand(2 * dim)
     A = rand(dim, dim)
     B = rand(dim, dim)
     C = rand(dim, dim)
+    D = [rand(dim, dim), rand(dim, dim)]
+    E = rand(2 * dim, dim)
 
     # Create random numbers
     alpha = rand()
@@ -244,11 +248,13 @@
         DistSpec(s -> MvNormal(to_posdef_diagonal(s)), (a,), b),
         DistSpec(s -> MvNormal(dim, s), (alpha,), a),
         DistSpec((m, A) -> TuringMvNormal(m, to_posdef(A)), (a, A), b),
+        DistSpec((m, A) -> TuringMvNormal(m, to_posdef.(A)), (d, D), e),
         DistSpec(TuringMvNormal, (a, b), c),
         DistSpec((m, s) -> TuringMvNormal(m, to_posdef_diagonal(s)), (a, b), c),
         DistSpec(TuringMvNormal, (a, alpha), b),
         DistSpec((m, s) -> TuringMvNormal(m, s^2 * I), (a, alpha), b),
         DistSpec(A -> TuringMvNormal(to_posdef(A)), (A,), a),
+        DistSpec(A -> TuringMvNormal(to_posdef.(A)), (D,), d),
         DistSpec(TuringMvNormal, (a,), b),
         DistSpec(s -> TuringMvNormal(to_posdef_diagonal(s)), (a,), b),
         DistSpec(s -> TuringMvNormal(dim, s), (alpha,), a),

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -26,7 +26,7 @@ using Random, LinearAlgebra, Test
 
 using Distributions: meanlogdet
 using DistributionsAD: TuringUniform, TuringMvNormal, TuringMvLogNormal,
-                       TuringPoissonBinomial
+                       TuringPoissonBinomial, TuringMFMvNormal
 using StatsBase: entropy
 using StatsFuns: binomlogpdf, logsumexp, logistic
 


### PR DESCRIPTION
This PR aims at adding the type `TuringMFMvNormal` for a structured mean-field implementation of the multivariate Gaussian, i.e. for $(x_1, x_2, ...., x_n) = x ~ q(x) = \prod_i^M q_{S_i}(x_{S_i})$ where $S_i$ are $M$ disjoint subsets of $(1,2, ... n)$.
Basically you want some group of variables to be correlated and others to be independent. This is especially useful for variational inference as the inference cost is decreased.
I used the `BlockDiagonal` implementation from [`BlockDiagonals.jl`](https://github.com/invenia/BlockDiagonals.jl) to inforce the independence between group of variables.
There seems to be still some issues with the AD, I will be looking into it