### PR TITLE
Relaxed parametrization of TuringDenseMvNormal and add new constructor

### DIFF
--- a/src/multivariate.jl
+++ b/src/multivariate.jl
@@ -90,17 +90,22 @@ end
 
 A multivariate Normal distribution whose covariance is dense. Compatible with Tracker.
 """
-struct TuringDenseMvNormal{Tm<:AbstractVector, TC<:Cholesky} <: ContinuousMultivariateDistribution
+struct TuringDenseMvNormal{Tm<:AbstractVector, TC<:AbstractMatrix} <: ContinuousMultivariateDistribution
     m::Tm
     C::TC
 end
 function TuringDenseMvNormal(m::AbstractVector, A::AbstractMatrix)
-    return TuringDenseMvNormal(m, cholesky(A))
+    return TuringDenseMvNormal(m, cholesky(A).L)
 end
+
+function TuringSqrtDenseMvNormal(m::AbstractVector, C::AbstractMatrix)
+    TuringDenseMvNormal(m, C)
+end
+
 Base.length(d::TuringDenseMvNormal) = length(d.m)
 Distributions.rand(d::TuringDenseMvNormal, n::Int...) = rand(Random.GLOBAL_RNG, d, n...)
 function Distributions.rand(rng::Random.AbstractRNG, d::TuringDenseMvNormal, n::Int...)
-    return d.m .+ d.C.U' * adapt_randn(rng, d.m, length(d), n...)
+    return d.m .+ d.C * adapt_randn(rng, d.m, length(d), n...)
 end
 
 """


### PR DESCRIPTION
The idea is the following:
Right now `TuringDenseMvNormal` takes a covariance matrix `A` and stores its cholesky decomposition `C`, which is in return used to sample : `x = mu + C * z`.
However it would be beneficial to have a constructor that takes directly `X` as in `A = X * X'`, which is often done for variational inference for instance.
Indeed with `X` given we can sample similarly with `x = mu + X * z`, except that 1) we don't need to compute the cholesky, 2) It allows for low rank matrices!

Right now I am a bit confused by the way tests are run, so I don't know how to add this one in the tests