### PR TITLE
Fix and test `TuringDirichlet` constructors

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "DistributionsAD"
 uuid = "ced4e74d-a319-5a8a-b0ac-84af2272839c"
-version = "0.6.18"
+version = "0.6.19"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/src/reversediff.jl
+++ b/src/reversediff.jl
@@ -260,13 +260,13 @@ Dirichlet(alpha::AbstractVector{<:TrackedReal}) = TuringDirichlet(alpha)
 Dirichlet(d::Integer, alpha::TrackedReal) = TuringDirichlet(d, alpha)
 
 function _logpdf(d::Dirichlet, x::AbstractVector{<:TrackedReal})
-    return _logpdf(TuringDirichlet(d.alpha, d.alpha0, d.lmnB), x)
+    return _logpdf(TuringDirichlet(d), x)
 end
 function logpdf(d::Dirichlet, x::AbstractMatrix{<:TrackedReal})
-    return logpdf(TuringDirichlet(d.alpha, d.alpha0, d.lmnB), x)
+    return logpdf(TuringDirichlet(d), x)
 end
 function loglikelihood(d::Dirichlet, x::AbstractMatrix{<:TrackedReal})
-    return loglikelihood(TuringDirichlet(d.alpha, d.alpha0, d.lmnB), x)
+    return loglikelihood(TuringDirichlet(d), x)
 end
 
 # default definition of `loglikelihood` yields gradients of zero?!

--- a/src/tracker.jl
+++ b/src/tracker.jl
@@ -371,13 +371,13 @@ Distributions.Dirichlet(alpha::TrackedVector) = TuringDirichlet(alpha)
 Distributions.Dirichlet(d::Integer, alpha::TrackedReal) = TuringDirichlet(d, alpha)
 
 function Distributions._logpdf(d::Dirichlet, x::TrackedVector{<:Real})
-    return Distributions._logpdf(TuringDirichlet(d.alpha, d.alpha0, d.lmnB), x)
+    return Distributions._logpdf(TuringDirichlet(d), x)
 end
 function Distributions.logpdf(d::Dirichlet, x::TrackedMatrix{<:Real})
-    return logpdf(TuringDirichlet(d.alpha, d.alpha0, d.lmnB), x)
+    return logpdf(TuringDirichlet(d), x)
 end
 function Distributions.loglikelihood(d::Dirichlet, x::TrackedMatrix{<:Real})
-    return loglikelihood(TuringDirichlet(d.alpha, d.alpha0, d.lmnB), x)
+    return loglikelihood(TuringDirichlet(d), x)
 end
 
 # Fix ambiguities
@@ -615,4 +615,3 @@ Distributions.InverseWishart(df::TrackedReal, S::AbstractMatrix{<:Real}) = Turin
 Distributions.InverseWishart(df::Real, S::TrackedMatrix) = TuringInverseWishart(df, S)
 Distributions.InverseWishart(df::TrackedReal, S::TrackedMatrix) = TuringInverseWishart(df, S)
 Distributions.InverseWishart(df::TrackedReal, S::AbstractPDMat{<:TrackedReal}) = TuringInverseWishart(df, S)
-

--- a/test/others.jl
+++ b/test/others.jl
@@ -298,4 +298,42 @@
             end
         end
     end
+
+    @test "TuringDirichlet" begin
+        dim = 3
+        n = 4
+        for alpha in (2, rand())
+            d1 = TuringDirichlet(dim, alpha)
+            d2 = Dirichlet(dim, alpha)
+            d3 = TuringDirichlet(d2)
+            @test d1.alpha == d2.alpha == d3.alpha
+            @test d1.alpha0 == d2.alpha0 == d3.alpha0
+            @test d1.lmnB == d2.lmnB == d3.lmnB
+
+            s1 = rand(d1)
+            @test s1 isa Vector{Float64}
+            @test length(s1) == dim
+
+            s2 = rand(d1, n)
+            @test s2 isa Matrix{Float64}
+            @test size(s2) == (dim, n)
+        end
+
+        for alpha in (ones(Int, dim), rand(dim))
+            d1 = TuringDirichlet(alpha)
+            d2 = Dirichlet(alpha)
+            d3 = TuringDirichlet(d2)
+            @test d1.alpha == d2.alpha == d3.alpha
+            @test d1.alpha0 == d2.alpha0 == d3.alpha0
+            @test d1.lmnB == d2.lmnB == d3.lmnB
+
+            s1 = rand(d1)
+            @test s1 isa Vector{Float64}
+            @test length(s1) == dim
+
+            s2 = rand(d1, n)
+            @test s2 isa Matrix{Float64}
+            @test size(s2) == (dim, n)
+        end
+    end
 end

--- a/test/others.jl
+++ b/test/others.jl
@@ -299,7 +299,7 @@
         end
     end
 
-    @test "TuringDirichlet" begin
+    @testset "TuringDirichlet" begin
         dim = 3
         n = 4
         for alpha in (2, rand())

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -10,7 +10,7 @@ using Random, LinearAlgebra, Test
 
 using Distributions: meanlogdet
 using DistributionsAD: TuringUniform, TuringMvNormal, TuringMvLogNormal,
-                       TuringPoissonBinomial
+                       TuringPoissonBinomial, TuringDirichlet
 using StatsBase: entropy
 using StatsFuns: binomlogpdf, logsumexp, logistic
 


### PR DESCRIPTION
This PR fixes https://github.com/TuringLang/Turing.jl/issues/1530 by relaxing the type constraints of `TuringDirichlet`, in line with recent updates in Distributions that allow integer-valued parameters.

It should also be more efficient to use `Fill` instead of `fill` (again in line with changes in Distributions).

I added some tests. Tests of Turing master pass locally with this PR.