### PR TITLE
Fix errors with Adapt 3.3.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ version = "0.6.22"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
+ChainRules = "082447d4-558c-5d27-93f4-14fc19e9eca2"
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
 DiffRules = "b552c78f-8df3-52c6-915a-8e097449b14b"
@@ -23,6 +24,7 @@ ZygoteRules = "700de1a5-db45-46bc-99cf-38207098b444"
 
 [compat]
 Adapt = "2, 3"
+ChainRules = "0.7"
 ChainRulesCore = "0.9.21"
 Compat = "3.6"
 DiffRules = "0.1, 1.0"

--- a/Project.toml
+++ b/Project.toml
@@ -4,7 +4,6 @@ version = "0.6.21"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
-ChainRules = "082447d4-558c-5d27-93f4-14fc19e9eca2"
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
 DiffRules = "b552c78f-8df3-52c6-915a-8e097449b14b"
@@ -24,8 +23,7 @@ ZygoteRules = "700de1a5-db45-46bc-99cf-38207098b444"
 
 [compat]
 Adapt = "2, 3"
-ChainRules = "0.7"
-ChainRulesCore = "0.9.9"
+ChainRulesCore = "0.9.21"
 Compat = "3.6"
 DiffRules = "0.1, 1.0"
 Distributions = "0.23.3, 0.24"

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "DistributionsAD"
 uuid = "ced4e74d-a319-5a8a-b0ac-84af2272839c"
-version = "0.6.21"
+version = "0.6.22"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/src/DistributionsAD.jl
+++ b/src/DistributionsAD.jl
@@ -9,7 +9,6 @@ using PDMats,
       Compat,
       Requires,
       ZygoteRules,
-      ChainRules,  # needed for `ChainRules.chol_blocked_rev`
       ChainRulesCore,
       FillArrays,
       Adapt

--- a/src/DistributionsAD.jl
+++ b/src/DistributionsAD.jl
@@ -9,6 +9,7 @@ using PDMats,
       Compat,
       Requires,
       ZygoteRules,
+      ChainRules,  # needed for `ChainRules.chol_blocked_rev`
       ChainRulesCore,
       FillArrays,
       Adapt

--- a/src/common.jl
+++ b/src/common.jl
@@ -45,11 +45,4 @@ Base.@pure __parameterless_type(T) = Base.typename(T).wrapper
 parameterless_type(x) = parameterless_type(typeof(x))
 parameterless_type(x::Type) = __parameterless_type(x)
 
-# TODO: should be replaced by @non_differentiable when
-# https://github.com/JuliaDiff/ChainRulesCore.jl/issues/212 is fixed
-function ChainRules.rrule(::typeof(adapt_randn), rng::AbstractRNG, x::AbstractArray, dims...)
-    function adapt_randn_pullback(ΔQ)
-        return (NO_FIELDS, Zero(), Zero(), map(_ -> Zero(), dims)...)
-    end
-    adapt_randn(rng, x, dims...), adapt_randn_pullback
-end
+ChainRulesCore.@non_differentiable adapt_randn(::Any...)

--- a/src/common.jl
+++ b/src/common.jl
@@ -45,4 +45,4 @@ Base.@pure __parameterless_type(T) = Base.typename(T).wrapper
 parameterless_type(x) = parameterless_type(typeof(x))
 parameterless_type(x::Type) = __parameterless_type(x)
 
-ChainRulesCore.@non_differentiable adapt_randn(::Any...)
+@non_differentiable adapt_randn(::Any...)

--- a/src/forwarddiff.jl
+++ b/src/forwarddiff.jl
@@ -1,5 +1,5 @@
 function adapt_randn(rng::AbstractRNG, x::AbstractArray{<:ForwardDiff.Dual}, dims...)
-    adapt(typeof(x), randn(rng, ForwardDiff.valtype(eltype(x)), dims...))
+    return adapt_randn(rng, ForwardDiff.valtype(eltype(x)), x, dims...)
 end
 
 ## Binomial ##


### PR DESCRIPTION
This PR fixes errors with Adapt 3.3.0 (see https://github.com/SciML/OrdinaryDiffEq.jl/issues/1369#issuecomment-817286051 for an explanation why it broke `adapt_randn`).

Additionally, I used the opportunity to replace the custom `rrule` with `@non_differentiable` which now supports varargs (moreover, it defines a `frule` as well and uses an optimized definition with `@nospecialize`).