### PR TITLE
Load ForwardDiff correctly

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "DistributionsAD"
 uuid = "ced4e74d-a319-5a8a-b0ac-84af2272839c"
-version = "0.6.24"
+version = "0.6.25"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/src/DistributionsAD.jl
+++ b/src/DistributionsAD.jl
@@ -62,12 +62,17 @@ include("zygote.jl")
 
 @init begin
     @require ForwardDiff="f6369f11-7733-5829-9624-2563aa707210" begin
+        using .ForwardDiff
         using .ForwardDiff: @define_binary_dual_op # Needed for `eval`ing diffrules here
         include("forwarddiff.jl")
     end
 
     @require ReverseDiff = "37e2e3b7-166d-5795-8a7a-e32c996b4267" begin
-        include("reversediff.jl")
+        # ensures that we can load ForwardDiff without depending on it
+        # (it is a dependency of ReverseDiff and therefore always available)
+        @require ForwardDiff="f6369f11-7733-5829-9624-2563aa707210" begin
+            include("reversediff.jl")
+        end
     end
 
     @require Tracker="9f7883ad-71c0-57eb-9f7f-b5c9e6d3789c" begin

--- a/src/reversediff.jl
+++ b/src/reversediff.jl
@@ -7,10 +7,10 @@ using ..ReverseDiff
 using StaticArrays
 using Distributions
 using PDMats
-using ForwardDiff
+using ..ForwardDiff
 
 using Base.Broadcast: BroadcastStyle, ArrayStyle, Broadcasted, broadcasted
-using ForwardDiff: Dual
+using ..ForwardDiff: Dual
 using ..ReverseDiff: SpecialInstruction, value, value!, deriv, track, record!,
                      tape, unseed!, @grad, TrackedReal, TrackedVector,
                      TrackedMatrix, TrackedArray


### PR DESCRIPTION
This PR fixes https://github.com/TuringLang/DistributionsAD.jl/issues/163 for me locally.

@gideonsimpson can you check that it fixes the warning for you as well? You can install this branch with
```julia
julia> ] add DistributionsAD#dw/forwarddiff
```