### PR TITLE
Update ChainRulesCore

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "DistributionsAD"
 uuid = "ced4e74d-a319-5a8a-b0ac-84af2272839c"
-version = "0.6.26"
+version = "0.6.27"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/Project.toml
+++ b/Project.toml
@@ -24,7 +24,7 @@ ZygoteRules = "700de1a5-db45-46bc-99cf-38207098b444"
 [compat]
 Adapt = "2, 3"
 ChainRules = "0.7"
-ChainRulesCore = "0.9.21"
+ChainRulesCore = "0.9.44, 0.10"
 Compat = "3.6"
 DiffRules = "0.1, 1.0"
 Distributions = "0.23.3, 0.24, 0.25"

--- a/Project.toml
+++ b/Project.toml
@@ -23,7 +23,7 @@ ZygoteRules = "700de1a5-db45-46bc-99cf-38207098b444"
 
 [compat]
 Adapt = "2, 3"
-ChainRules = "0.7"
+ChainRules = "0.7, 0.8"
 ChainRulesCore = "0.9.44, 0.10"
 Compat = "3.6"
 DiffRules = "0.1, 1.0"

--- a/src/chainrules.jl
+++ b/src/chainrules.jl
@@ -118,7 +118,7 @@ function ChainRulesCore.rrule(
             @thunk(A * Δy),
             Δ -> LinearAlgebra.mul!(Δ, A, Δy, true, true),
         )
-        return (NO_FIELDS, p̄)
+        return (NoTangent(), p̄)
     end
     return y, poissonbinomial_pdf_fft_pullback
 end
@@ -134,7 +134,7 @@ if isdefined(Distributions, :poissonbinomial_pdf)
                 @thunk(A * Δy),
                 Δ -> LinearAlgebra.mul!(Δ, A, Δy, true, true),
             )
-            return (NO_FIELDS, p̄)
+            return (NoTangent(), p̄)
         end
         return y, poissonbinomial_pdf_pullback
     end

--- a/src/chainrules.jl
+++ b/src/chainrules.jl
@@ -118,7 +118,7 @@ function ChainRulesCore.rrule(
             @thunk(A * Δy),
             Δ -> LinearAlgebra.mul!(Δ, A, Δy, true, true),
         )
-        return (NoTangent(), p̄)
+        return (NO_FIELDS, p̄)
     end
     return y, poissonbinomial_pdf_fft_pullback
 end
@@ -134,7 +134,7 @@ if isdefined(Distributions, :poissonbinomial_pdf)
                 @thunk(A * Δy),
                 Δ -> LinearAlgebra.mul!(Δ, A, Δy, true, true),
             )
-            return (NoTangent(), p̄)
+            return (NO_FIELDS, p̄)
         end
         return y, poissonbinomial_pdf_pullback
     end

--- a/src/common.jl
+++ b/src/common.jl
@@ -7,7 +7,7 @@ end
 function turing_chol_back(A::AbstractMatrix, check)
     C, chol_pullback = rrule(cholesky, A, Val(false), check=check)
     function back(Δ)
-        Ȳ = Composite{typeof(C)}((U=Δ[1]))
+        Ȳ = Tangent{typeof(C)}((U=Δ[1]))
         ∂C = chol_pullback(Ȳ)[2]
         (∂C, nothing)
     end
@@ -21,7 +21,7 @@ end
 function symm_turing_chol_back(A::AbstractMatrix, check, uplo)
     C, chol_pullback = rrule(cholesky, Symmetric(A,uplo), Val(false), check=check)
     function back(Δ)
-        Ȳ = Composite{typeof(C)}((U=Δ[1]))
+        Ȳ = Tangent{typeof(C)}((U=Δ[1]))
         ∂C = chol_pullback(Ȳ)[2]
         (∂C, nothing, nothing)
     end

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -17,8 +17,8 @@ Tracker = "9f7883ad-71c0-57eb-9f7f-b5c9e6d3789c"
 Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 
 [compat]
-ChainRulesCore = "0.9"
-ChainRulesTestUtils = "0.6.3"
+ChainRulesCore = "0.9.44, 0.10"
+ChainRulesTestUtils = "0.6.3, 0.7"
 Combinatorics = "1.0.2"
 Distributions = "0.24.3, 0.25"
 FiniteDifferences = "0.11.3, 0.12"

--- a/test/ad/chainrules.jl
+++ b/test/ad/chainrules.jl
@@ -34,14 +34,15 @@
     test_frule(StatsFuns.tdistlogpdf, x, y)
     test_rrule(StatsFuns.tdistlogpdf, x, y)
 
+    # TODO: Re-enable if https://github.com/JuliaMath/SpecialFunctions.jl/pull/325 is fixed
     # use `BigFloat` to avoid Rmath implementation in finite differencing check
     # (returns `NaN` for non-integer values)
-    n = rand(1:100)
-    x = BigFloat(n)
-    y = big(logistic(randn()))
-    z = BigFloat(rand(1:n))
-    test_frule(StatsFuns.binomlogpdf, x, y, z)
-    test_rrule(StatsFuns.binomlogpdf, x, y, z)
+    #n = rand(1:100)
+    #x = BigFloat(n)
+    #y = big(logistic(randn()))
+    #z = BigFloat(rand(1:n))
+    #test_frule(StatsFuns.binomlogpdf, x, y, z)
+    #test_rrule(StatsFuns.binomlogpdf, x, y, z)
 
     x = big(exp(randn()))
     y = BigFloat(rand(1:100))

--- a/test/ad/distributions.jl
+++ b/test/ad/distributions.jl
@@ -54,8 +54,8 @@
         DistSpec(Poisson, (0.5,), 1),
         DistSpec(Poisson, (0.5,), [1, 1]),
 
-        DistSpec(Skellam, (1.0, 2.0), -2; broken=(:Zygote,)),
-        DistSpec(Skellam, (1.0, 2.0), [-2, -2]; broken=(:Zygote,)),
+        DistSpec(Skellam, (1.0, 2.0), -2),
+        DistSpec(Skellam, (1.0, 2.0), [-2, -2]),
 
         DistSpec(PoissonBinomial, ([0.5, 0.5],), 0),
 
@@ -162,7 +162,7 @@
 
         DistSpec(NormalCanon, (1.0, 2.0), 0.5),
 
-        DistSpec(NormalInverseGaussian, (1.0, 2.0, 1.0, 1.0), 0.5; broken=(:Zygote,)),
+        DistSpec(NormalInverseGaussian, (1.0, 2.0, 1.0, 1.0), 0.5),
 
         DistSpec(Pareto, (1.0,), 1.5),
         DistSpec(Pareto, (1.0, 1.0), 1.5),

--- a/test/ad/distributions.jl
+++ b/test/ad/distributions.jl
@@ -164,6 +164,7 @@
 
         DistSpec(NormalInverseGaussian, (1.0, 2.0, 1.0, 1.0), 0.5),
 
+        DistSpec(Pareto, (), 1.5),
         DistSpec(Pareto, (1.0,), 1.5),
         DistSpec(Pareto, (1.0, 1.0), 1.5),
 
@@ -213,10 +214,7 @@
         # Stackoverflow caused by SpecialFunctions.besselix
         DistSpec(VonMises, (1.0,), 1.0),
         DistSpec(VonMises, (1, 1), 1),
-        
-        # Only some Zygote tests are broken and therefore this can not be checked
-        DistSpec(Pareto, (), 1.5; broken=(:Zygote,)),
-        
+
         # Some tests are broken on some Julia versions, therefore it can't be checked reliably
         DistSpec(PoissonBinomial, ([0.5, 0.5],), [0, 0]; broken=(:Zygote,)),
     ]


### PR DESCRIPTION
In ChainRulesCore >= 0.9.44 some names were changed and deprecated, and then removed in ChainRulesCore 0.10. This PR updates ChainRulesCore and fixes these deprecations.