### PR TITLE
Faster filldist()

### DIFF
--- a/src/arraydist.jl
+++ b/src/arraydist.jl
@@ -22,10 +22,10 @@ function Distributions._logpdf(dist::MatrixOfUnivariate, x::AbstractMatrix{<:Rea
     return sum(Broadcast.instantiate(Broadcast.broadcasted(logpdf, dist.dists, x)))
 end
 function Distributions.logpdf(dist::MatrixOfUnivariate, x::AbstractArray{<:AbstractMatrix{<:Real}})
-    return map(x -> logpdf(dist, x), x)
+    return map(Base.Fix1(logpdf, dist), x)
 end
 function Distributions.logpdf(dist::MatrixOfUnivariate, x::AbstractArray{<:Matrix{<:Real}})
-    return map(x -> logpdf(dist, x), x)
+    return map(Base.Fix1(logpdf, dist), x)
 end
 
 function Distributions.rand(rng::Random.AbstractRNG, dist::MatrixOfUnivariate)
@@ -51,13 +51,13 @@ function Distributions._logpdf(dist::VectorOfMultivariate, x::AbstractMatrix{<:R
     return sum(((di, xi),) -> logpdf(di, xi), zip(dist.dists, eachcol(x)))
 end
 function Distributions.logpdf(dist::VectorOfMultivariate, x::AbstractArray{<:AbstractMatrix{<:Real}})
-    return map(x -> logpdf(dist, x), x)
+    return map(Base.Fix1(logpdf, dist), x)
 end
 function Distributions.logpdf(dist::VectorOfMultivariate, x::AbstractArray{<:Matrix{<:Real}})
-    return map(x -> logpdf(dist, x), x)
+    return map(Base.Fix1(logpdf, dist), x)
 end
 
 function Distributions.rand(rng::Random.AbstractRNG, dist::VectorOfMultivariate)
     init = reshape(rand(rng, dist.dists[1]), :, 1)
-    return mapreduce(i -> rand(rng, dist.dists[i]), hcat, 2:length(dist); init = init)
+    return mapreduce(Base.Fix1(rand, rng), hcat, view(dist.dists, 2:length(dist)); init = init)
 end

--- a/src/arraydist.jl
+++ b/src/arraydist.jl
@@ -3,7 +3,7 @@
 const VectorOfUnivariate = Distributions.Product
 
 function arraydist(dists::AbstractVector{<:UnivariateDistribution})
-    return Product(dists)
+    return product_distribution(dists)
 end
 
 struct MatrixOfUnivariate{

--- a/src/arraydist.jl
+++ b/src/arraydist.jl
@@ -18,7 +18,9 @@ function arraydist(dists::AbstractMatrix{<:UnivariateDistribution})
     return MatrixOfUnivariate(dists)
 end
 function Distributions._logpdf(dist::MatrixOfUnivariate, x::AbstractMatrix{<:Real})
-    return mapreduce(logpdf, +, dist.dists, x)
+    # Lazy broadcast to avoid allocations and use pairwise summation
+    y = Broadcast.instantiate(Broadcast.broadcasted(logpdf, dist.dists, x))
+    return sum(y)
 end
 function Distributions.logpdf(dist::MatrixOfUnivariate, x::AbstractArray{<:AbstractMatrix{<:Real}})
     return map(x -> logpdf(dist, x), x)

--- a/src/arraydist.jl
+++ b/src/arraydist.jl
@@ -18,7 +18,7 @@ function arraydist(dists::AbstractMatrix{<:UnivariateDistribution})
     return MatrixOfUnivariate(dists)
 end
 function Distributions._logpdf(dist::MatrixOfUnivariate, x::AbstractMatrix{<:Real})
-    return mapreduce((disti, xi) -> logpdf(disti, xi), +, dist.dists, x)
+    return mapreduce(logpdf, +, dist.dists, x)
 end
 function Distributions.logpdf(dist::MatrixOfUnivariate, x::AbstractArray{<:AbstractMatrix{<:Real}})
     return map(x -> logpdf(dist, x), x)

--- a/src/arraydist.jl
+++ b/src/arraydist.jl
@@ -3,7 +3,10 @@
 const VectorOfUnivariate = Distributions.Product
 
 function arraydist(dists::AbstractVector{<:UnivariateDistribution})
-    return product_distribution(dists)
+    V = typeof(dists)
+    T = eltype(dists)
+    S = Distributions.value_support(T)
+    return Product{S,T,V}(dists)
 end
 
 struct MatrixOfUnivariate{

--- a/src/arraydist.jl
+++ b/src/arraydist.jl
@@ -48,7 +48,7 @@ function arraydist(dists::AbstractVector{<:MultivariateDistribution})
 end
 
 function Distributions._logpdf(dist::VectorOfMultivariate, x::AbstractMatrix{<:Real})
-    return sum(((di, xi),) -> logpdf(di, xi), zip(dist.dists, eachcol(x)))
+    return sum(Broadcast.instantiate(Broadcast.broadcasted(logpdf, dist.dists, eachcol(x))))
 end
 function Distributions.logpdf(dist::VectorOfMultivariate, x::AbstractArray{<:AbstractMatrix{<:Real}})
     return map(Base.Fix1(logpdf, dist), x)

--- a/src/arraydist.jl
+++ b/src/arraydist.jl
@@ -19,8 +19,7 @@ function arraydist(dists::AbstractMatrix{<:UnivariateDistribution})
 end
 function Distributions._logpdf(dist::MatrixOfUnivariate, x::AbstractMatrix{<:Real})
     # Lazy broadcast to avoid allocations and use pairwise summation
-    y = Broadcast.instantiate(Broadcast.broadcasted(logpdf, dist.dists, x))
-    return sum(y)
+    return sum(Broadcast.instantiate(Broadcast.broadcasted(logpdf, dist.dists, x)))
 end
 function Distributions.logpdf(dist::MatrixOfUnivariate, x::AbstractArray{<:AbstractMatrix{<:Real}})
     return map(x -> logpdf(dist, x), x)

--- a/src/arraydist.jl
+++ b/src/arraydist.jl
@@ -18,9 +18,7 @@ function arraydist(dists::AbstractMatrix{<:UnivariateDistribution})
     return MatrixOfUnivariate(dists)
 end
 function Distributions._logpdf(dist::MatrixOfUnivariate, x::AbstractMatrix{<:Real})
-    # return sum(((d, xi),) -> logpdf(d, xi), zip(dist.dists, x))
-    # Broadcasting here breaks Tracker for some reason
-    return sum(map(logpdf, dist.dists, x))
+    return mapreduce((disti, xi) -> logpdf(disti, xi), +, dist.dists, x)
 end
 function Distributions.logpdf(dist::MatrixOfUnivariate, x::AbstractArray{<:AbstractMatrix{<:Real}})
     return map(x -> logpdf(dist, x), x)

--- a/src/filldist.jl
+++ b/src/filldist.jl
@@ -30,7 +30,7 @@ end
 function _flat_logpdf(dist, x)
     if toflatten(dist)
         f, args = flatten(dist)
-        return mapreduce(xi -> f(args..., xi), +, x)
+        return sum(xi -> f(args..., xi), x)
     else
         return mapreduce(Base.Fix1(logpdf, dist), +, x)
     end

--- a/src/filldist.jl
+++ b/src/filldist.jl
@@ -30,21 +30,18 @@ end
 function _flat_logpdf(dist, x)
     if toflatten(dist)
         f, args = flatten(dist)
-        return sum(f.(args..., x))
+        return mapreduce(xi -> f(args..., xi), +, x)
     else
-        return sum(map(x) do x
-            logpdf(dist, x)
-        end)
+        return mapreduce(xi -> logpdf(dist, xi), +, x)
     end
 end
 
 function _flat_logpdf_mat(dist, x)
     if toflatten(dist)
         f, args = flatten(dist)
-        return vec(sum(f.(args..., x), dims = 1))
+        return vec(mapreduce(xi -> f(args..., xi), +, x, dims = 1))
     else
-        temp = map(x -> logpdf(dist, x), x)
-        return vec(sum(temp, dims = 1))
+        return vec(mapreduce(xi -> logpdf(dist, xi), +, x, dims = 1))
     end
 end
 

--- a/src/filldist.jl
+++ b/src/filldist.jl
@@ -32,7 +32,7 @@ function _flat_logpdf(dist, x)
         f, args = flatten(dist)
         return mapreduce(xi -> f(args..., xi), +, x)
     else
-        return mapreduce(xi -> logpdf(dist, xi), +, x)
+        return mapreduce(Base.Fix1(logpdf, dist), +, x)
     end
 end
 
@@ -41,7 +41,7 @@ function _flat_logpdf_mat(dist, x)
         f, args = flatten(dist)
         return vec(mapreduce(xi -> f(args..., xi), +, x, dims = 1))
     else
-        return vec(mapreduce(xi -> logpdf(dist, xi), +, x, dims = 1))
+        return vec(mapreduce(Base.Fix1(logpdf, dist), +, x; dims = 1))
     end
 end
 

--- a/src/filldist.jl
+++ b/src/filldist.jl
@@ -30,9 +30,10 @@ end
 function _flat_logpdf(dist, x)
     if toflatten(dist)
         f, args = flatten(dist)
-        return sum(xi -> f(args..., xi), x)
+        # Lazy broadcast to avoid allocations and use pairwise summation
+        return sum(Broadcast.instantiate(Broadcast.broadcasted(xi -> f(args..., xi), x)))
     else
-        return mapreduce(Base.Fix1(logpdf, dist), +, x)
+        return sum(Broadcast.instantiate(Broadcast.broadcasted(Base.Fix1(logpdf, dist), x)))
     end
 end
 

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -17,7 +17,7 @@ Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 
 [compat]
 ChainRulesCore = "1"
-ChainRulesTestUtils = "1"
+ChainRulesTestUtils = "1.9.2"
 Combinatorics = "1.0.2"
 Distributions = "0.25.15"
 FiniteDifferences = "0.11.3, 0.12"

--- a/test/ad/distributions.jl
+++ b/test/ad/distributions.jl
@@ -411,7 +411,8 @@
             filldist_broken = if D <: PoissonBinomial
                 ((d.broken..., :Zygote), (d.broken..., :Zygote))
             elseif D <: Chernoff
-                ((d.broken..., :Zygote), (d.broken..., :Zygote))
+                # Zygote is not broken with `filldist`
+                ((), ())
             else
                 (d.broken, d.broken)
             end

--- a/test/ad/distributions.jl
+++ b/test/ad/distributions.jl
@@ -413,8 +413,7 @@
             elseif D <: PoissonBinomial
                 ((d.broken..., :Zygote), (d.broken..., :Zygote))
             elseif D <: Chernoff
-                # Zygote is not broken with `filldist`
-                ((), ())
+                ((d.broken..., :Zygote), (d.broken..., :Zygote))
             else
                 (d.broken, d.broken)
             end

--- a/test/ad/distributions.jl
+++ b/test/ad/distributions.jl
@@ -409,7 +409,7 @@
             # Matrix case does not work with Skellam:
             # https://github.com/TuringLang/DistributionsAD.jl/pull/172#issuecomment-853721493
             filldist_broken = if D <: Skellam
-                ((d.broken..., :Zygote, :ReverseDiff), (d.broken..., :Zygote, :ReverseDiff))
+                ((d.broken..., :ReverseDiff), (d.broken..., :ReverseDiff))
             elseif D <: PoissonBinomial
                 ((d.broken..., :Zygote), (d.broken..., :Zygote))
             elseif D <: Chernoff

--- a/test/ad/distributions.jl
+++ b/test/ad/distributions.jl
@@ -408,9 +408,7 @@
             # PoissonBinomial fails with Zygote
             # Matrix case does not work with Skellam:
             # https://github.com/TuringLang/DistributionsAD.jl/pull/172#issuecomment-853721493
-            filldist_broken = if D <: Skellam
-                ((d.broken..., :ReverseDiff), (d.broken..., :ReverseDiff))
-            elseif D <: PoissonBinomial
+            filldist_broken = if D <: PoissonBinomial
                 ((d.broken..., :Zygote), (d.broken..., :Zygote))
             elseif D <: Chernoff
                 ((d.broken..., :Zygote), (d.broken..., :Zygote))

--- a/test/ad/utils.jl
+++ b/test/ad/utils.jl
@@ -396,11 +396,15 @@ function testset_zygote(distspec, unpack_x_θ, args...; kwargs...)
     end
 end
 
-function testset_zygote_broken(args...; kwargs...)
+function testset_zygote_broken(distspec, args...; kwargs...)
     # don't show test errors - tests are known to be broken :)
     testset = suppress_stdout() do
-        testset_zygote(args...; kwargs...)
+        testset_zygote(distspec, args...; kwargs...)
     end
+
+    f = distspec.f
+    θ = distspec.θ
+    x = distspec.x
 
     # change errors and fails to broken results, and count number of errors and fails
     efs = errors_to_broken!(testset)


### PR DESCRIPTION
Switch `logpdf(::FillDist)` from `sum(map(f, x))` to `mapreduce(f, +, x)` to eliminate the unnecessary array allocations.

`sum(f, x)` would have been even simpler, but I'm hitting `*(::TrackedReal, ::Dual)` method ambiguity on this path.

It's beyond my current understanding of the autodiff code to figure out whether just this change breaks some tests (`Chernoff` distribution) and fixes other (`Zygote`) or it is just a coincidence.

I have tried to `@benchmark` the change, but with `@benchmark(logpdf($(filldist(Cauchy(), 1000)), $(rand(1000))))` I don't see much of the change.
I guess it starts to be visible with dual numbers.

So here's the profiling results.

Before:
<img src="https://user-images.githubusercontent.com/348591/177661071-8388ab46-5fd4-4b00-9f99-d3db140f5584.png" width="500">

After:
<img src="https://user-images.githubusercontent.com/348591/177661086-47f8b19b-94ad-4c66-8182-998051bc8db4.png" width="500">

Note that array allocation and copying disappear, and it looks like overall it should be ~30% faster.
