### PR TITLE
Fix deprecation warnings of `Product` constructor

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "DistributionsAD"
 uuid = "ced4e74d-a319-5a8a-b0ac-84af2272839c"
-version = "0.6.41"
+version = "0.6.42"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/src/arraydist.jl
+++ b/src/arraydist.jl
@@ -3,7 +3,7 @@
 const VectorOfUnivariate = Distributions.Product
 
 function arraydist(dists::AbstractVector{<:UnivariateDistribution})
-    return Product(dists)
+    return product_distribution(dists)
 end
 
 struct MatrixOfUnivariate{

--- a/src/arraydist.jl
+++ b/src/arraydist.jl
@@ -3,7 +3,10 @@
 const VectorOfUnivariate = Distributions.Product
 
 function arraydist(dists::AbstractVector{<:UnivariateDistribution})
-    return product_distribution(dists)
+    V = typeof(dists)
+    T = eltype(dists)
+    S = Distributions.value_support(T)
+    return Product{S,T,V}(dists)
 end
 
 struct MatrixOfUnivariate{


### PR DESCRIPTION
`Product` is deprecated in favour of `product_distribution` in Distributions >0.25.64.