### PR TITLE
LazyArrays.jl extension is broken

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "DistributionsAD"
 uuid = "ced4e74d-a319-5a8a-b0ac-84af2272839c"
-version = "0.6.47"
+version = "0.6.48"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/ext/DistributionsADLazyArraysExt.jl
+++ b/ext/DistributionsADLazyArraysExt.jl
@@ -3,12 +3,12 @@ module DistributionsADLazyArraysExt
 if isdefined(Base, :get_extension)
     using DistributionsAD
     using LazyArrays
-    using DistributionsAD: Distributions
+    using DistributionsAD: Distributions, ValueSupport
     using LazyArrays: BroadcastArray, BroadcastVector, LazyArray
 else
     using ..DistributionsAD
     using ..LazyArrays
-    using ..DistributionsAD: Distributions
+    using ..DistributionsAD: Distributions, ValueSupport
     using ..LazyArrays: BroadcastArray, BroadcastVector, LazyArray
 end
 


### PR DESCRIPTION
Extension for LazyArrays is using `ValueSupport` without having imported it. This fixes that.