### PR TITLE
Bump compat for Adapt to 4

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -31,7 +31,7 @@ DistributionsADReverseDiffExt = "ReverseDiff"
 DistributionsADTrackerExt = "Tracker"
 
 [compat]
-Adapt = "2, 3"
+Adapt = "2, 3, 4"
 ChainRules = "1.35.3"
 ChainRulesCore = "1"
 Compat = "3.6, 4"


### PR DESCRIPTION
Adapt v4.0.0 features breaking changes in `Adapt.ndims`, `Adapt.eltype` and `Adapt.parent`
(see https://github.com/JuliaGPU/Adapt.jl/releases/tag/v4.0.0)

DistributionsAD.jl seems to be using only `Adapt.adapt` [here](https://github.com/TuringLang/DistributionsAD.jl/blob/b7c2184b7791fa5f379ef3948e760961890eb40f/src/common.jl#L42), so it should not be affected by the changes in Adapt v4.0.0.

Closes #262.
