### PR TITLE
Added default impls for `filldist` and `arraydist`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "DistributionsAD"
 uuid = "ced4e74d-a319-5a8a-b0ac-84af2272839c"
-version = "0.6.54"
+version = "0.6.55"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/src/arraydist.jl
+++ b/src/arraydist.jl
@@ -1,3 +1,10 @@
+"""
+    arraydist(dists)
+
+Create a distribution from an array of distributions.
+"""
+arraydist(dists::AbstractArray) = product_distribution(dists)
+
 # Univariate
 
 const VectorOfUnivariate = Distributions.Product

--- a/src/filldist.jl
+++ b/src/filldist.jl
@@ -1,5 +1,14 @@
+# Default implementation just defers to Distributions.jl.
+"""
+    filldist(d::Distribution, ns...)
+
+Create a product distribution using `FillArrays.Fill` as the array type.
+"""
+filldist(d::Distribution, ns...) = product_distribution(Fill(d, ns...))
+
 # Univariate
 
+# TODO: Do we even need these? Probably should benchmark to be sure.
 const FillVectorOfUnivariate{
     S <: ValueSupport,
     T <: UnivariateDistribution{S},


### PR DESCRIPTION
Currently we don't support something like `filldist(Dirichlet(ones(2)), 3, 4)` even though there is a distribution impl available in Distributions.jl through `product_distribution`.

This PR adds such default impls for high-dim calls to `filldist` and `arraydist`; AD might be worse performance-wise but we should still support it.

https://github.com/TuringLang/Turing.jl/issues/2190