### PR TITLE
Fix MethodAmbiguity errors

### DIFF
--- a/src/filldist.jl
+++ b/src/filldist.jl
@@ -68,7 +68,7 @@ const FillMatrixOfUnivariate{
     Tdists <: Fill{T, 2},
 } = MatrixOfUnivariate{S, T, Tdists}
 
-function filldist(dist::UnivariateDistribution, N1::Integer, N2::Integer)
+function filldist(dist::UnivariateDistribution, N1::Int, N2::Int)
     return MatrixOfUnivariate(Fill(dist, N1, N2))
 end
 function Distributions._logpdf(dist::FillMatrixOfUnivariate, x::AbstractMatrix{<:Real})


### PR DESCRIPTION
Possibly this fixes the method ambiguity issues in #264. At least it shows that there is an inconsistency in the definition of `filldist` currently - most methods are defined for `Int`s but one is defined for `Integer`s.